### PR TITLE
Logging and reading the Z-buffer depth in bits from a scene node

### DIFF
--- a/src/scenejs/scene/scene.js
+++ b/src/scenejs/scene/scene.js
@@ -176,6 +176,17 @@ SceneJS.Scene.prototype.getCanvasId = function() {
     return this._canvasId;
 };
 
+/** Returns the Z-buffer depth in bits of the webgl context that this scene is to bound to. 
+ */
+SceneJS.Scene.prototype.getZBufferDepth = function() {
+    var context;
+    if (this._sceneId) {
+        context = SceneJS._sceneModule.getSceneContext(this._sceneId);
+        return context.getParameter(context.DEPTH_BITS)
+    }    
+    return context;
+};
+
 /**
  Sets which layers are included in the next render of this scene, along with their priorities (default priority is 0)
  @param {{String:Number}} layers - render priority for each layer defined in scene

--- a/src/scenejs/scene/sceneModule.js
+++ b/src/scenejs/scene/sceneModule.js
@@ -230,6 +230,17 @@ SceneJS._sceneModule = new (function() {
         return scene.canvas.canvas;
     };
 
+    /** Returns the webgl context element the given scene is bound to
+     * @private
+     */
+    this.getSceneContext = function(sceneId) {
+        var scene = scenes[sceneId];
+        if (!scene) {
+            throw SceneJS._errorModule.fatalError("Scene not defined: '" + sceneId + "'");
+        }
+        return scene.canvas.context;
+    };
+
     /** Returns all registered scenes
      * @private
      */


### PR DESCRIPTION
I've had some issues with far clipping artifacts when the Z-buffer depth in bits is small so being able to log and report find this information is useful.

There are two commits which can be considered separately. 

The first displays the Z-buffer depth in bits to the console info on scene creation

example:

```
SceneJS V0.7.9.0 initialised
SceneJS.Scene binding to canvas 'theCanvas'
SceneJS.Scene using webgl context with Z-buffer depth of: 24 bits
SceneJS.Scene logging to element with ID 'theLoggingDiv' - logging to browser console also
Scene defined: s0
...
```

The second adds a ZBufferDepth readable attribute to the scene node

example:

```
SceneJS.withNode("theScene").get("ZBufferDepth")
=> 24
```
