### PR TITLE
Correct canvas size for webgl when the canvas is sized with css styling

### DIFF
--- a/src/scenejs/scene/sceneModule.js
+++ b/src/scenejs/scene/sceneModule.js
@@ -97,6 +97,12 @@ SceneJS._sceneModule = new (function() {
                 }
             }
         }
+        
+        // If the canvas uses css styles to specify the sizes make sure the basic 
+        // width and height attributes match or the WebGL context will use 300 x 150
+        canvas.width = canvas.clientWidth;
+        canvas.height = canvas.clientHeight;
+        
         var context;
         var contextNames = SceneJS.SUPPORTED_WEBGL_CONTEXT_NAMES;
         for (var i = 0; (!context) && i < contextNames.length; i++) {


### PR DESCRIPTION
When the size of a canvas element is set with css styles instead of specifying the size in the element itself the canvas displays using the css styles but reports a default height and width (300 x 150).

When creating a webgl context the canvas attributes height and width are used so if the canvas size is specified with a css style the resulting webgl viewport will be incorrect.

This branch with one commit is based off of master.
