### PR TITLE
Bbox event state-changed incorrect oldState

### DIFF
--- a/src/scenejs/boundary/boundingBox.js
+++ b/src/scenejs/boundary/boundingBox.js
@@ -142,10 +142,11 @@ SceneJS.BoundingBox.STATE_INTERSECTING_FRUSTUM = "visible";
 
 // @private
 SceneJS.BoundingBox.prototype._changeState = function(newState, params) {
+    var oldState = this._state;
     this._state = newState;
     if (this._listeners["state-changed"]) {
         params = params || {};
-        params.oldState = this._state;
+        params.oldState = oldState;
         params.newState = newState;
         this._fireEvent("state-changed", params);
     }


### PR DESCRIPTION
Previously the params.oldState was set to the newState incorrectly

Same issue exists in v0.8, same fix is applicable.
