### PR TITLE
Remove call to destroy() on programs, they are generic JS objects

### DIFF
--- a/src/scenejs/shading/renderModule.js
+++ b/src/scenejs/shading/renderModule.js
@@ -255,9 +255,6 @@ var SceneJS_renderModule = new (function() {
     SceneJS_eventModule.addListener(
             SceneJS_eventModule.RESET,
             function() {
-                for (var programId in programs) {  // Just free allocated programs
-                    programs[programId].destroy();
-                }
                 programs = {};
                 nextProgramId = 0;
             });


### PR DESCRIPTION
Was getting an error that Object doesn't have destroy().

Removed the call to destroy() on programs.

This seems to be correct. I tested in my project that has scenes which get destroyed and re-created at runtime and it seems to work without any complaints/errors.

Forgot to set the author on my commit, but it's me!
