### PR TITLE
Fix flicker after picking (picking on dirty scene)

### DIFF
--- a/src/scenejs/scene/scene.js
+++ b/src/scenejs/scene/scene.js
@@ -371,7 +371,7 @@ new (function() {
             throw SceneJS_errorModule.fatalError(SceneJS.errors.NODE_ILLEGAL_STATE, "Scene has been destroyed");
         }
         options = options || {};
-        this._compileScene();                   // Do any pending scene recompilations
+        this.renderFrame();                   // Do any pending scene recompilations
         var hit = SceneJS_DrawList.pick({
             sceneId: this.attr.id,
             canvasX : canvasX,


### PR DESCRIPTION
Flickering appears in the following situation:
Picking is performed very short after the scene was changed (scene dirty), so short, that no rendering was performed in between.
In this situation the picking recompiles the dirty scene, and the next rendering (which should take place) does not take place anymore, because after picking the scene is not dirty anymore.
