### PR TITLE
Fix rebuilding programs after context loss

### DIFF
--- a/src/core/display/program.js
+++ b/src/core/display/program.js
@@ -51,12 +51,6 @@ var SceneJS_Program = function(id, hash, source, gl) {
      */
     this.useCount = 0;
 
-    /**
-     * Current draw uniform state cached as a bitfield to avoid costly extra uniform1i calls
-     * @type Number
-     */
-    this.drawUniformFlags = 0;
-
     this.build(gl);
 };
 
@@ -65,6 +59,12 @@ var SceneJS_Program = function(id, hash, source, gl) {
  * This is also re-called to re-create them after WebGL context loss.
  */
 SceneJS_Program.prototype.build = function(gl) {
+    /**
+     * Current draw uniform state cached as a bitfield to avoid costly extra uniform1i calls
+     * @type Number
+     */
+    this.drawUniformFlags = 0;
+
     this.gl = gl;
     this.draw = new SceneJS_webgl_Program(gl, [this.source.drawVertexSrc.join("\n")], [this.source.drawFragmentSrc.join("\n")]);
     this.pick = new SceneJS_webgl_Program(gl, [this.source.pickVertexSrc.join("\n")], [this.source.pickFragmentSrc.join("\n")]);


### PR DESCRIPTION
Uniform state needs to be reinitialized after context loss occurs.

Fixes a regression introduced by commit "Cache shader program uniform
state to avoid redundant uniform1i calls".
