### PR TITLE
Make chunk IDs strings and fix programGlobal

### DIFF
--- a/src/core/display/chunks/chunk.js
+++ b/src/core/display/chunks/chunk.js
@@ -14,7 +14,7 @@ var SceneJS_Chunk = function() {};
  * when recycling a chunk from its free chunk pool. This method sets the given properties on the chunk, then calls the
  * chunk instance's <b>build</b> method if the chunk has been augmented with one.
  *
- * @param {Number} id Chunk ID
+ * @param {String} id Chunk ID
  * @param {SceneJS_Program} program Program to render the chunk
  * @param {SceneJS_Core} core The state core rendered by this chunk
  */

--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -449,15 +449,18 @@ SceneJS_Display.prototype._setChunk = function (object, order, chunkType, core, 
             return;
         }
 
-        chunkId = chunkClass.programGlobal
-            ? core.stateId + 1
-            : ((object.program.id + 1) * 50000) + core.stateId + 1;
+        // Note that core.stateId can be either a number or a string, that's why we make
+        // chunkId a string here. String stateId can come from at least nodeEvents.js.
+        // TODO: Would it be better if all were numbers?
+        chunkId = chunkClass.prototype.programGlobal
+            ? '_' + core.stateId
+            : 'p' + object.program.id + '_' + core.stateId;
 
     } else {
 
         // No core supplied, probably a program.
         // Only one chunk of this type per program.
-        chunkId = ((object.program.id + 1) * 50000);
+        chunkId = 'p' + object.program.id;
     }
 
     var oldChunk = object.chunks[order];


### PR DESCRIPTION
programGlobal is set to chunkClass.prototype, not chunkClass. Chunk IDs
are made to always be strings, rather than a mix of strings and numbers
as they previously were.
