### PR TITLE
Update morphing examples

### DIFF
--- a/examples/pages/geometry/morphing.html
+++ b/examples/pages/geometry/morphing.html
@@ -34,7 +34,7 @@
             // http://scenejs.org/api/latest/plugins/node/cameras/orbit.js
             {
                 type:"cameras/orbit",
-                yaw:30,
+                yaw:70,
                 pitch:-30,
                 zoom:30,
                 zoomSensitivity:1.0,
@@ -48,13 +48,11 @@
                             /*------------------------------------------------------
                              * The morphGeometry
                              *
-                             * We could morph everything on the geometry except
-                             * of course for the indices array. In this example, we're
-                             * just morphing the positions and normals between two
-                             * targets.
+                             * We can morph positions and normals. In this example,
+                             * we're morphing between three targets.
                              *
-                             * The 'factor' attribute takes a value from 0.0 to 1.0
-                             * to interpolate between the first and last target.
+                             * The 'factor' attribute takes a value from 0.0 to 2.0
+                             * to choose targets and interpolate between them.
                              *
                              * We'll animate that as we run the scene to drive the
                              * morphing.
@@ -67,7 +65,7 @@
                                  */
                                 factor:0.0,
 
-                                keys:[0, 2],
+                                keys:[0, 1, 2],
 
                                 /* Minimum of two morph targets required
                                  */
@@ -76,14 +74,30 @@
                                     /* Target 1
                                      */
                                     {
-                                        positions:[ 5, 5, 0, -5, 5, 0, -5, -5, 0, 5, -5, 0 ],
+                                        positions:[ 5, 5, 5,
+                                                    -5, 5, 0,
+                                                    -5, -5, 5,
+                                                    5, -5, 0 ],
                                         normals:[-1, 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0 ]
                                     },
 
                                     /* Target 2
                                      */
                                     {
-                                        positions:[ 0, 5, 5, 0, 5, -5, 0, -5, -5, 0, -5, 5 ],
+                                        positions:[ 6, 6, 0,
+                                                    -6, 6, 0,
+                                                    -6, -6, 0,
+                                                    6, -6, 0 ],
+                                        normals:[ 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1 ]
+                                    },
+
+                                    /* Target 3
+                                     */
+                                    {
+                                        positions:[ 5, 5, 0,
+                                                    -5, 5, 0,
+                                                    -5, -5, 0,
+                                                    0, 0, -5 ],
                                         normals:[ 0, 0, -1, 0, 0, -1, 0, 0, -1, 0, 0, -1 ]
                                     }
                                 ],
@@ -96,9 +110,6 @@
                                      * Note that the positions and normals are
                                      * omitted because those are specified on the
                                      * morphGeometry.
-                                     *
-                                     * We're not morphing the UV coords, so we'll
-                                     * specify them on the geometry.
                                      *
                                      * We can have multiple geometries in a
                                      * morphGeometry, perhaps to divide up the
@@ -136,9 +147,9 @@
 
         scene.on("tick",
                 function () {
-                    if (factor >= 1.0) {
+                    if (factor >= 2.0) {
                         factorInc *= -1;
-                    } else if (factor < -1) {
+                    } else if (factor < 0.0) {
                         factorInc *= -1;
                     }
                     factor += factorInc;

--- a/examples/pages/geometry/morphingTypedArrays.html
+++ b/examples/pages/geometry/morphingTypedArrays.html
@@ -57,10 +57,8 @@
                             /*------------------------------------------------------
                              * The morphGeometry
                              *
-                             * We could morph everything on the geometry except
-                             * of course for the indices array. In this example, we're
-                             * just morphing the positions and normals between two
-                             * targets.
+                             * We can morph positions and normals. In this example,
+                             * we're just morphing them between two targets.
                              *
                              * The 'factor' attribute takes a value from 0.0 to 1.0
                              * to interpolate between the first and last target.
@@ -76,7 +74,7 @@
                                  */
                                 factor:0.0,
 
-                                keys:[0, 2],
+                                keys:[0, 1],
 
                                 /* Minimum of two morph targets required
                                  */
@@ -147,7 +145,7 @@
                 function () {
                     if (factor >= 1.0) {
                         factorInc *= -1;
-                    } else if (factor < -1) {
+                    } else if (factor < 0) {
                         factorInc *= -1;
                     }
                     factor += factorInc;


### PR DESCRIPTION
Morph between three targets instead of two in one of the examples so that
it tests the case where the morph keys change. Correct comments to say
that only morphing positions and normals is supported, others are not
supported by the shader. Also make the morphing range consistent with the
comments.
