### PR TITLE
morphGeometry update events

### DIFF
--- a/examples/geometry_morphTargets.html
+++ b/examples/geometry_morphTargets.html
@@ -13,7 +13,7 @@
             -webkit-user-select: none;
         }
 
-        #morph-target-pair {
+        #morph-target-pair, #morph-factor {
             font-size: 16px;
         }
     </style>
@@ -25,7 +25,8 @@
 
 <div id="infoDark">
     <a href="http://scenejs.org">SceneJS</a> - geometry morph targets - trivial demo<br>
-    Current target pair: <span id="morph-target-pair">0-1</span>
+    Current target pair: <span id="morph-target-pair">0-1</span><br>
+    Current interpolation factor: <span id="morph-factor">0</span>
 </div>
 
 <script>
@@ -155,9 +156,14 @@
                 var factor = 0;
                 var factorInc = 0.01;
                 var targetPairElement = document.getElementById("morph-target-pair");
+                var factorElement = document.getElementById("morph-factor");
 
                 myMorph.on("frameUpdate", function(frame) {
                     targetPairElement.innerText = frame.key1 + "-" + frame.key2;
+                });
+
+                myMorph.on("update", function(frame) {
+                    factorElement.innerText = frame.factor.toFixed(3);
                 });
 
                 scene.on("tick",

--- a/examples/geometry_morphTargets.html
+++ b/examples/geometry_morphTargets.html
@@ -12,6 +12,10 @@
             -khtml-user-select: none;
             -webkit-user-select: none;
         }
+
+        #morph-target-pair {
+            font-size: 16px;
+        }
     </style>
 
     <script src="../api/latest/scenejs.js"></script>
@@ -20,7 +24,8 @@
 <body>
 
 <div id="infoDark">
-    <a href="http://scenejs.org">SceneJS</a> - geometry morph targets - trivial demo
+    <a href="http://scenejs.org">SceneJS</a> - geometry morph targets - trivial demo<br>
+    Current target pair: <span id="morph-target-pair">0-1</span>
 </div>
 
 <script>
@@ -149,6 +154,11 @@
 
                 var factor = 0;
                 var factorInc = 0.01;
+                var targetPairElement = document.getElementById("morph-target-pair");
+
+                myMorph.on("frameUpdate", function(frame) {
+                    targetPairElement.innerText = frame.key1 + "-" + frame.key2;
+                });
 
                 scene.on("tick",
                         function () {

--- a/src/core/scene/morphGeometry.js
+++ b/src/core/scene/morphGeometry.js
@@ -313,11 +313,17 @@ new (function () {
             }
         }
 
+        var frameUpdate = key1 != core.key1;
+
         /* Normalise factor to range [0.0..1.0] for the target frame
          */
         core.factor = (factor - keys[key1]) / (keys[key2] - keys[key1]);
         core.key1 = key1;
         core.key2 = key2;
+
+        if (frameUpdate) {
+            this.publish("frameUpdate", this.getCurrentFrame());
+        }
 
         this._engine.display.imageDirty = true;
     };
@@ -332,6 +338,18 @@ new (function () {
 
     SceneJS.MorphGeometry.prototype.getTargets = function () {
         return this._core.targets;
+    };
+
+    SceneJS.MorphGeometry.prototype.getCurrentFrame = function () {
+        var key1 = this._core.key1;
+        var key2 = this._core.key2;
+        return {
+            key1: key1,
+            key2: key2,
+            factor: this._core.factor,
+            target1: this._core.targets[key1],
+            target2: this._core.targets[key2]
+        }
     };
 
     SceneJS.MorphGeometry.prototype._compile = function (ctx) {

--- a/src/core/scene/morphGeometry.js
+++ b/src/core/scene/morphGeometry.js
@@ -341,14 +341,15 @@ new (function () {
     };
 
     SceneJS.MorphGeometry.prototype.getCurrentFrame = function () {
-        var key1 = this._core.key1;
-        var key2 = this._core.key2;
+        var core = this._core;
+        var key1 = core.key1;
+        var key2 = core.key2;
         return {
             key1: key1,
             key2: key2,
-            factor: this._core.factor,
-            target1: this._core.targets[key1],
-            target2: this._core.targets[key2]
+            factor: core.factor,
+            target1: core.targets[key1],
+            target2: core.targets[key2]
         }
     };
 

--- a/src/core/scene/morphGeometry.js
+++ b/src/core/scene/morphGeometry.js
@@ -294,6 +294,8 @@ new (function () {
         var key1 = core.key1;
         var key2 = core.key2;
 
+        var oldFactor = core.factor;
+
         if (factor < keys[0]) {
             key1 = 0;
             key2 = 1;
@@ -318,11 +320,18 @@ new (function () {
         /* Normalise factor to range [0.0..1.0] for the target frame
          */
         core.factor = (factor - keys[key1]) / (keys[key2] - keys[key1]);
+
+        var morphUpdate = frameUpdate || oldFactor != core.factor;
+
         core.key1 = key1;
         core.key2 = key2;
 
-        if (frameUpdate) {
-            this.publish("frameUpdate", this.getCurrentFrame());
+        if (morphUpdate) {
+            var currentFrame = this.getCurrentFrame();
+            this.publish("update", currentFrame);
+            if (frameUpdate) {
+                this.publish("frameUpdate", currentFrame);
+            }
         }
 
         this._engine.display.imageDirty = true;


### PR DESCRIPTION
Added some events and a method to the morphGeometry node to provide information about the current state of a morph:
- Method `getCurrentFrame()` returns an object that contains the following morph state information:
  - `key1`, `key2`: The currently active key pair
  - `target1`, `target2`: The morph targets currently being interpolated
  - `factor`: The current interpolation factor
- Event `update` triggered whenever the morph animates.
- Event `frameUpdate` triggered whenever the current frame (key pair) changes.