### PR TITLE
Bug fix for FPS control animation loop

### DIFF
--- a/api/latest/scenejs.js
+++ b/api/latest/scenejs.js
@@ -2284,19 +2284,18 @@ SceneJS_Engine.prototype.start = function () {
                 }
 
                 requestAnimationFrame(draw);
+            }
 
-                if (self.running) {
-                    if (self.fps > 0) {
-                        window.setTimeout(window[fnName], 1000 / self.fps);
-                    } else {
-                        requestAnimationFrame(window[fnName]);
-                    }
-                    
-                } 
+            if (self.running) {
+                if (self.fps > 0) {
+                    setTimeout(window[fnName], 1000 / self.fps);
+                } else {
+                    requestAnimationFrame(window[fnName]);
+                }
             }
         };
 
-        window[fnName]();
+        setTimeout(window[fnName], 0);
     }
 };
 
@@ -11938,7 +11937,7 @@ SceneJS.Scene.prototype.start = function (params) {
 };
 
 /**
- * Starts the render loop for this scene
+ * Set refresh rate for the scene
  */
 SceneJS.Scene.prototype.setFPS = function (fps) {
     this._engine.fps = fps;

--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -469,19 +469,18 @@ SceneJS_Engine.prototype.start = function () {
                 }
 
                 requestAnimationFrame(draw);
+            }
 
-                if (self.running) {
-                    if (self.fps > 0) {
-                        window.setTimeout(window[fnName], 1000 / self.fps);
-                    } else {
-                        requestAnimationFrame(window[fnName]);
-                    }
-                    
-                } 
+            if (self.running) {
+                if (self.fps > 0) {
+                    setTimeout(window[fnName], 1000 / self.fps);
+                } else {
+                    requestAnimationFrame(window[fnName]);
+                }
             }
         };
 
-        window[fnName]();
+        setTimeout(window[fnName], 0);
     }
 };
 

--- a/src/core/scene/scene.js
+++ b/src/core/scene/scene.js
@@ -114,7 +114,7 @@ SceneJS.Scene.prototype.start = function (params) {
 };
 
 /**
- * Starts the render loop for this scene
+ * Set refresh rate for the scene
  */
 SceneJS.Scene.prototype.setFPS = function (fps) {
     this._engine.fps = fps;


### PR DESCRIPTION
This fixes a bug in my recent FPS control update that caused the animation loop to be completely cancelled if the scene was paused.