### PR TITLE
Set fragment shader float precision to max available.

### DIFF
--- a/api/latest/scenejs.js
+++ b/api/latest/scenejs.js
@@ -15552,7 +15552,6 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
     this._sourceCache = {}; // Source codes are shared across all scenes
 
-
     /**
      * Get sourcecode for a program to render the given states
      */
@@ -15631,8 +15630,10 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         var clipping = states.clips.clips.length > 0;
 
+        var floatPrecision = getFSFloatPrecision(states._canvas.gl);
+
         var src = [
-            "precision mediump float;"
+            "precision " + floatPrecision + " float;"
         ];
 
         src.push("varying vec4 SCENEJS_vWorldVertex;");
@@ -16050,9 +16051,11 @@ var SceneJS_ProgramSourceFactory = new (function () {
         var tangents = this._hasTangents(states);
         var clipping = states.clips.clips.length > 0;
 
+        var floatPrecision = getFSFloatPrecision(states._canvas.gl);
+
         var src = ["\n"];
 
-        src.push("precision mediump float;");
+        src.push("precision " + floatPrecision + " float;");
 
 
         if (clipping) {
@@ -16445,6 +16448,22 @@ var SceneJS_ProgramSourceFactory = new (function () {
             }
         }
         return false;
+    }
+
+    function getFSFloatPrecision(gl) {
+        if (!gl.getShaderPrecisionFormat) {
+            return "mediump";
+        }
+
+        if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision > 0) {
+            return "highp";
+        }
+
+        if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.MEDIUM_FLOAT).precision > 0) {
+            return "mediump";
+        }
+
+        return "lowp";
     }
 
 })();/**

--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -6,7 +6,6 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
     this._sourceCache = {}; // Source codes are shared across all scenes
 
-
     /**
      * Get sourcecode for a program to render the given states
      */
@@ -85,8 +84,10 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         var clipping = states.clips.clips.length > 0;
 
+        var floatPrecision = getFSFloatPrecision(states._canvas.gl);
+
         var src = [
-            "precision mediump float;"
+            "precision " + floatPrecision + " float;"
         ];
 
         src.push("varying vec4 SCENEJS_vWorldVertex;");
@@ -504,9 +505,11 @@ var SceneJS_ProgramSourceFactory = new (function () {
         var tangents = this._hasTangents(states);
         var clipping = states.clips.clips.length > 0;
 
+        var floatPrecision = getFSFloatPrecision(states._canvas.gl);
+
         var src = ["\n"];
 
-        src.push("precision mediump float;");
+        src.push("precision " + floatPrecision + " float;");
 
 
         if (clipping) {
@@ -899,6 +902,22 @@ var SceneJS_ProgramSourceFactory = new (function () {
             }
         }
         return false;
+    }
+
+    function getFSFloatPrecision(gl) {
+        if (!gl.getShaderPrecisionFormat) {
+            return "mediump";
+        }
+
+        if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision > 0) {
+            return "highp";
+        }
+
+        if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.MEDIUM_FLOAT).precision > 0) {
+            return "mediump";
+        }
+
+        return "lowp";
     }
 
 })();


### PR DESCRIPTION
This update sets the float precision of the fragment shader to the maximum available on the client platform.

The forced mediump precision for the fragment shader caused artifacts to appear on iOS, as shown in the following image:
![scenejs-fs](https://cloud.githubusercontent.com/assets/476017/7994614/c27ed458-0adc-11e5-9382-b908d578ce76.PNG)
