### PR TITLE
Don't request animation frame if already at animation frame

### DIFF
--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -469,7 +469,11 @@ SceneJS_Engine.prototype.start = function () {
                     return;
                 }
 
-                requestAnimationFrame(draw);
+                if (self.fps > 0) {
+                    requestAnimationFrame(draw);
+                } else {
+                    draw();  // Already at an animation frame.
+                }
             }
 
             if (self.running) {


### PR DESCRIPTION
Minor optimization to the FPS control code.

Basically, when using the browser's refresh rate (i.e. no throttling), the code would call `requestAnimationFrame` twice, once for the update logic and once to draw. This fixes that issue and should result in slightly smoother animation.