### PR TITLE
Got frontface check for solid clipping working on OSX

### DIFF
--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -636,7 +636,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
             if (solid) {
 
-                src.push("  if (!gl_FrontFacing) {");
+                src.push("  if (gl_FrontFacing == false) {");
                 src.push("     gl_FragColor = vec4(0.4, 0.4, 1.0, 1.0);");
                 src.push("     return;");
                 src.push("  }");


### PR DESCRIPTION
This seems to be another bug in the Mac OpenGL implementation. Seems you have explicitly compare to a bool. Tested in Chrome, Firefox and Safari.