### PR TITLE
Geometry, morphGeometry memory optimization

### DIFF
--- a/src/core/display/chunks/drawChunk.js
+++ b/src/core/display/chunks/drawChunk.js
@@ -23,8 +23,6 @@ SceneJS_ChunkFactory.createChunkType({
 
         var gl = this.program.gl;
 
-        var indexType = this.program.UINT_INDEX_ENABLED ? gl.UNSIGNED_INT : gl.UNSIGNED_SHORT;
-
         if (frameCtx.pick) {
             if (this._depthModePick) {
                 this._depthModePick.setValue(frameCtx.depthMode);
@@ -35,7 +33,7 @@ SceneJS_ChunkFactory.createChunkType({
             }
         }
 
-        gl.drawElements(this.core.primitive, this.core.indexBuf.numItems, indexType, 0);
+        gl.drawElements(this.core.primitive, this.core.indexBuf.numItems, this.core.indexBuf.itemType, 0);
 
         //frameCtx.textureUnit = 0;
     }

--- a/src/core/display/program.js
+++ b/src/core/display/program.js
@@ -34,12 +34,6 @@ var SceneJS_Program = function(id, hash, source, gl) {
     this.gl = gl;
 
     /**
-     * Whether or not we can use UINT indices
-     * @type boolean
-     */
-    this.UINT_INDEX_ENABLED = !!gl.getExtension("OES_element_index_uint");
-
-    /**
      * The drawing program
      * @type SceneJS._webgl.Program
      */

--- a/src/core/scene/geometry.js
+++ b/src/core/scene/geometry.js
@@ -67,24 +67,59 @@ new (function () {
         }
 
         // Create typed arrays, apply any baked transforms
-        core.arrays = {
-            positions: data.positions
-                ? new Float32Array((options.scale || options.origin)
-                ? this._applyOptions(data.positions, options)
-                : data.positions) : undefined,
-            normals: data.normals ? new Float32Array(data.normals) : undefined,
-            uv: data.uv ? new Float32Array(data.uv) : undefined,
-            uv2: data.uv2 ? new Float32Array(data.uv2) : undefined,
-            colors: data.colors ? new Float32Array(data.colors) : undefined,
-            indices: data.indices ? new IndexArrayType(data.indices) : undefined
-        };
+        core.arrays = {};
 
-        delete data.positions;
-        delete data.normals;
-        delete data.uv;
-        delete data.uv2;
-        delete data.indices;
-        delete data.colors;
+        if (data.positions) {
+          if (data.positions.constructor != Float32Array) {
+            data.positions = new Float32Array(data.positions);
+          }
+
+          if (options.scale || options.origin) {
+            this._applyOptions(data.positions, options)
+          }
+
+          core.arrays.positions = data.positions;
+        }
+
+        if (data.normals) {
+          if (data.normals.constructor != Float32Array) {
+            data.normals = new Float32Array(data.normals);
+          }
+
+          core.arrays.normals = data.normals;
+        }
+
+        if (data.uv) {
+          if (data.uv.constructor != Float32Array) {
+            data.uv = new Float32Array(data.uv);
+          }
+
+          core.arrays.uv = data.uv;
+        }
+
+        if (data.uv2) {
+          if (data.uv2.constructor != Float32Array) {
+            data.uv2 = new Float32Array(data.uv2);
+          }
+
+          core.arrays.uv2 = data.uv2;
+        }
+
+        if (data.colors) {
+          if (data.colors.constructor != Float32Array) {
+            data.colors = new Float32Array(data.colors);
+          }
+
+          core.arrays.colors = data.colors;
+        }
+
+        if (data.indices) {
+          if (data.indices.constructor != Uint16Array && data.indices.constructor != Uint32Array) {
+            data.indices = new IndexArrayType(data.indices);
+          }
+
+          core.arrays.indices = data.indices;
+        }
 
         // Lazy-build tangents, only when needed as rendering
         core.getTangentBuf = function () {
@@ -147,35 +182,33 @@ new (function () {
      */
     SceneJS.Geometry.prototype._applyOptions = function (positions, options) {
 
-        var positions2 = positions.slice ? positions.slice(0) : new Float32Array(positions);  // HACK
+      if (options.scale) {
 
-        if (options.scale) {
+        var scaleX = options.scale.x != undefined ? options.scale.x : 1.0;
+        var scaleY = options.scale.y != undefined ? options.scale.y : 1.0;
+        var scaleZ = options.scale.z != undefined ? options.scale.z : 1.0;
 
-            var scaleX = options.scale.x != undefined ? options.scale.x : 1.0;
-            var scaleY = options.scale.y != undefined ? options.scale.y : 1.0;
-            var scaleZ = options.scale.z != undefined ? options.scale.z : 1.0;
-
-            for (var i = 0, len = positions2.length; i < len; i += 3) {
-                positions2[i    ] *= scaleX;
-                positions2[i + 1] *= scaleY;
-                positions2[i + 2] *= scaleZ;
-            }
+        for (var i = 0, len = positions.length; i < len; i += 3) {
+          positions[i    ] *= scaleX;
+          positions[i + 1] *= scaleY;
+          positions[i + 2] *= scaleZ;
         }
+      }
 
-        if (options.origin) {
+      if (options.origin) {
 
-            var originX = options.origin.x != undefined ? options.origin.x : 0.0;
-            var originY = options.origin.y != undefined ? options.origin.y : 0.0;
-            var originZ = options.origin.z != undefined ? options.origin.z : 0.0;
+        var originX = options.origin.x != undefined ? options.origin.x : 0.0;
+        var originY = options.origin.y != undefined ? options.origin.y : 0.0;
+        var originZ = options.origin.z != undefined ? options.origin.z : 0.0;
 
-            for (var i = 0, len = positions2.length; i < len; i += 3) {
-                positions2[i    ] -= originX;
-                positions2[i + 1] -= originY;
-                positions2[i + 2] -= originZ;
-            }
+        for (var i = 0, len = positions.length; i < len; i += 3) {
+          positions[i    ] -= originX;
+          positions[i + 1] -= originY;
+          positions[i + 2] -= originZ;
         }
+      }
 
-        return positions2;
+      return positions;
     };
 
     /**
@@ -374,7 +407,7 @@ new (function () {
             nvecs[j2].push(n);
         }
 
-        var normals = new Array(positions.length);
+        var normals = new Float32Array(positions.length);
 
         // now go through and average out everything
         for (var i = 0, len = nvecs.length; i < len; i++) {

--- a/src/core/scene/morphGeometry.js
+++ b/src/core/scene/morphGeometry.js
@@ -216,30 +216,30 @@ new (function () {
 
                 arry = targetData.positions || positions;
                 if (arry) {
-                    target.positions = (typeof arry == "Float32Array") ? arry : new Float32Array(arry);
-                    target.vertexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.positions, arry.length, 3, usage);
-                    positions = arry;
+                  target.positions = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                  target.vertexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.positions, arry.length, 3, usage);
+                  positions = arry;
                 }
 
                 arry = targetData.normals || normals;
                 if (arry) {
-                    target.normals = (typeof arry == "Float32Array") ? arry : new Float32Array(arry);
-                    target.normalBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.normals, arry.length, 3, usage);
-                    normals = arry;
+                  target.normals = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                  target.normalBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.normals, arry.length, 3, usage);
+                  normals = arry;
                 }
 
                 arry = targetData.uv || uv;
                 if (arry) {
-                    target.uv = (typeof arry == "Float32Array") ? arry : new Float32Array(arry);
-                    target.uvBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv, arry.length, 2, usage);
-                    uv = arry;
+                  target.uv = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                  target.uvBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv, arry.length, 2, usage);
+                  uv = arry;
                 }
 
                 arry = targetData.uv2 || uv2;
                 if (arry) {
-                    target.uv2 = (typeof arry == "Float32Array") ? arry : new Float32Array(arry);
-                    target.uvBuf2 = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv2, arry.length, 2, usage);
-                    uv2 = arry;
+                  target.uv2 = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                  target.uvBuf2 = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv2, arry.length, 2, usage);
+                  uv2 = arry;
                 }
 
                 core.targets.push(target);  // We'll iterate this to destroy targets when we recover from error

--- a/src/core/webgl/arrayBuffer.js
+++ b/src/core/webgl/arrayBuffer.js
@@ -17,12 +17,17 @@ SceneJS._webgl.ArrayBuffer = function (gl, type, values, numItems, itemSize, usa
      */
     this.allocated = false;
 
+    var itemType = values.constructor == Uint8Array   ? gl.UNSIGNED_BYTE :
+                   values.constructor == Uint16Array  ? gl.UNSIGNED_SHORT :
+                   values.constructor == Uint32Array  ? gl.UNSIGNED_INT :
+                                                        gl.FLOAT;
+
     this.gl = gl;
     this.type = type;
+    this.itemType = itemType;
     this.numItems = numItems;
     this.itemSize = itemSize;
     this.usage = usage;
-
     this._allocate(values, numItems);
 };
 


### PR DESCRIPTION
Geometry and morphGeometry nodes will no longer create new typed data arrays if the provided arrays are already of the correct type. This essentially creates an optimization path whereby uses can avoid allocating memory for geometry data twice by simply providing typed arrays themselves.