### PR TITLE
Watch task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -50,6 +50,15 @@ module.exports = function (grunt) {
                 src: 'api/latest/<%= PROJECT_NAME %>.js',
                 dest: '<%= build_dir %>/<%= PROJECT_NAME %>-<%= ENGINE_VERSION %>.js'
             }
+        },
+        watch: {
+            scripts: {
+                files: ["<%= concat.engine.src %>", "Gruntfile.js"],
+                tasks: ["snapshot"],
+                options: {
+                  spawn: false,
+                },
+            },
         }
     });
 
@@ -57,6 +66,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-concat");
     grunt.loadNpmTasks("grunt-contrib-clean");
     grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-contrib-watch');
 
     // Builds snapshot libs within api/latest
     // Run this when testing examples locally against your changes before committing them

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-copy": "~0.8.0",
     "grunt-contrib-jasmine": "~0.8.2",
-    "grunt-contrib-qunit": "~0.5.2"
+    "grunt-contrib-qunit": "~0.5.2",
+    "grunt-contrib-watch": "~0.6.1"
   },
   "engines": {
     "node": ">=0.10.17",


### PR DESCRIPTION
Just something to make development a bit easier. Running `grunt watch` before you start coding will start a process that compiles a snapshot (`grunt snapshot`) on any code changes. This makes those code changes immediately available to the examples.