### PR TITLE
Fix texture node setSrc() and setImage()

### DIFF
--- a/examples/texture_video_specular.html
+++ b/examples/texture_video_specular.html
@@ -64,36 +64,27 @@
                                 space: "view"
                             }
                         ],
-
                         nodes: [
                             {
-                                type: "flags",
-                                flags: {
-                                    transparent: true
-                                },
+                                type: "material",
+                                color: { r: 0.5, g: 0.5, b: 0.6 },
+                                specularColor: { r: 0.7, g: 0.7, b: 0.8 },
+                                specular: 10.0,
+                                shine: 5.0,
                                 nodes: [
+
+                                    // Video texture, implemented by plugin at
+                                    // http://scenejs.org/api/latest/plugins/node/texture/video.js
                                     {
-                                        type: "material",
-                                        color: { r: 0.5, g: 0.5, b: 0.6 },
-                                        specularColor: { r: 0.7, g: 0.7, b: 0.8 },
-                                        specular: 10.0,
-                                        shine: 5.0,
+                                        type: "texture/video",
+                                        src: "movies/testVideo.ogv",
+                                        applyTo: "specular",
+
                                         nodes: [
 
-                                            // Video texture, implemented by plugin at
-                                            // http://scenejs.org/api/latest/plugins/node/texture/video.js
+                                            // Box primitive implemented by plugin at http://scenejs.org/api/latest/plugins/node/geometry/box.js
                                             {
-                                                type: "texture/video",
-                                                src: "movies/testVideo.ogv",
-                                                applyTo: "specular",
-
-                                                nodes: [
-
-                                                    // Box primitive implemented by plugin at http://scenejs.org/api/latest/plugins/node/geometry/box.js
-                                                    {
-                                                        type: "geometry/box"
-                                                    }
-                                                ]
+                                                type: "geometry/box"
                                             }
                                         ]
                                     }

--- a/src/core/scene/texture.js
+++ b/src/core/scene/texture.js
@@ -94,14 +94,14 @@ new (function () {
 
 
             if (params.src) { // Load from URL
-                var texture = this._initTexture(params.preloadColor);
+                this._initTexture(params.preloadColor);
                 this._core.src = params.src;
-                this._loadTexture(texture, params.src, params.preloadSrc);
+                this._loadTexture(params.src, params.preloadSrc);
 
             } else if (params.image) { // Create from image
-                var texture = this._initTexture(params.preloadColor);
+                this._initTexture(params.preloadColor);
                 this._core.image = params.image;
-                this._setTextureImage(texture, params.image);
+                this._setTextureImage(params.image);
 
             } else if (params.target) { // Render to this texture
                 this.getScene().getNode(params.target,
@@ -113,12 +113,12 @@ new (function () {
             this._core.webglRestored = function () {
                 
                 if (self._core.image) {
-                    var texture = self._initTexture(params.preloadColor);
-                    self._setTextureImage(texture, self._core.image);
+                    self._initTexture(params.preloadColor);
+                    self._setTextureImage(self._core.image);
 
                 } else if (self._core.src) {
-                    var texture = self._initTexture(params.preloadColor);
-                    self._loadTexture(texture, self._core.src);
+                    self._initTexture(params.preloadColor);
+                    self._loadTexture(self._core.src);
 
                 } else if (self._core.target) {
 //                    self.getScene().getNode(params.target,
@@ -172,11 +172,9 @@ new (function () {
         gl.bindTexture(gl.TEXTURE_2D, texture);
         gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, preloadColor);
         this._setCoreTexture(texture);
-
-        return texture;
     };
 
-    SceneJS.TextureMap.prototype._loadTexture = function (texture, src, preloadSrc) {
+    SceneJS.TextureMap.prototype._loadTexture = function (src, preloadSrc) {
         var self = this;
         var taskId = SceneJS_sceneStatusModule.taskStarted(this, "Loading texture");
         var image = new Image();
@@ -188,7 +186,7 @@ new (function () {
 
             preloadImage.onload = function () {
                 if (!loaded) {
-                    self._setTextureImage(texture, preloadImage);
+                    self._setTextureImage(preloadImage);
                     SceneJS_sceneStatusModule.taskFinished(taskId);
                     taskFinished = true;
                     self._engine.display.imageDirty = true; 
@@ -199,7 +197,7 @@ new (function () {
         }
 
         image.onload = function () {
-            self._setTextureImage(texture, image);
+            self._setTextureImage(image);
             if (!taskFinished) {
                 SceneJS_sceneStatusModule.taskFinished(taskId);
             }
@@ -221,11 +219,10 @@ new (function () {
         }
     };
 
-    SceneJS.TextureMap.prototype._setTextureImage = function (texture, image) {
-
+    SceneJS.TextureMap.prototype._setTextureImage = function (image) {
         var gl = this._engine.canvas.gl;
-
-        var texture = gl.createTexture();
+        var texture = this._core.texture ? this._core.texture.texture : gl.createTexture(); 
+       
         gl.bindTexture(gl.TEXTURE_2D, texture);
 
         var maxTextureSize = SceneJS_configsModule.configs.maxTextureSize;
@@ -299,7 +296,7 @@ new (function () {
         this._core.image = image;
         this._core.src = null;
         this._core.target = null;
-        this._initTexture(image);
+        this._setTextureImage(image);
     };
 
     SceneJS.TextureMap.prototype.setTarget = function (target) {


### PR DESCRIPTION
Fixes a regression caused by d54efe0e28b7a86b56eb83c32ded94511c64de8d.

Also removed transparency flag from specular video texture example, as it seemed to prevent it from working. That might be something worth looking into as well.

Fixes #367