### PR TITLE
Fixed bug in negative pow bug in fresnel shader

### DIFF
--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -687,15 +687,8 @@ var SceneJS_ProgramSourceFactory = new (function () {
         if (diffuseFresnel || specularFresnel || alphaFresnel || reflectFresnel || emitFresnel || fragmentFresnel) {
             src.push("float fresnel(vec3 viewDirection, vec3 worldNormal, float centerBias, float edgeBias, float power) {");
             src.push("    float fr = abs(dot(viewDirection, worldNormal));");
-            src.push("    float finalFr = (fr - edgeBias) / (centerBias - edgeBias);");
-            src.push("    float fresnelTerm = pow(finalFr, power);");
-            src.push("    return clamp(fresnelTerm, 0.0, 1.0);");
-
-            //
-            //
-            //src.push("  float fresnelTerm = pow(bias + abs(dot(viewDirection, worldNormal)), power);");
-            //src.push("  return clamp(fresnelTerm, 0., 1.);");
-
+            src.push("    float finalFr = clamp((fr - edgeBias) / (centerBias - edgeBias), 0.0, 1.0);");
+            src.push("    return pow(finalFr, power);");
             src.push("}");
         }
 

--- a/src/core/scene/fresnel.js
+++ b/src/core/scene/fresnel.js
@@ -8,8 +8,8 @@ new (function () {
     var defaultCore = {
         type: "fresnel",
         stateId: SceneJS._baseStateId++,
-        centerBias:0.0,
-        edgeBias: 1.0,
+        centerBias: 1.0,
+        edgeBias: 0.0,
         power: 1.0,
         centerColor:[ 1.0, 1.0, 1.0 ],
         edgeColor:[ 0.0, 0.0, 0.0 ],


### PR DESCRIPTION
There was an issue in the fresnel factor calculation that showed up if the facing ratio went below the value for edgeBias. I believe this is due to the problems GLSL [pow](https://www.opengl.org/sdk/docs/man/html/pow.xhtml) has with negative numbers. I'm not sure why, but the issue only seemed to show up when the edgeBias and centerBias were small and close to each other. The following example used an edgeBias of 0.1 and centerBias of 0.2.

Here's an example of the problem before the fix:

![screen shot 2015-09-09 at 4 32 52 pm](https://cloud.githubusercontent.com/assets/476017/9773731/07b930d2-5712-11e5-98fd-21ae7c247296.png)

And after:

![screen shot 2015-09-09 at 4 32 08 pm](https://cloud.githubusercontent.com/assets/476017/9773744/18561360-5712-11e5-972a-27e187ff1075.png)

Also fixed the fresnel node defaults to reflect the new conventions: 0 = edge, 1 = center.