### PR TITLE
Fresnel on emit color instead of weight

### DIFF
--- a/examples/fresnel_emit.html
+++ b/examples/fresnel_emit.html
@@ -69,11 +69,9 @@
                                 type: "material",
                                 color: {r: 0.6, g: 0.5, b: 0.5},
                                 specularColor: {r: 1.0, g: 1.0, b: 1.0},
-                                emitColor: {r: 1.0, g: 0.5, b: 0.0},
                                 specular: 1.0,
                                 shine: 70.0,
                                 emit: 1.0,
-
                                 nodes: [
 
                                     // Emissive fresnel
@@ -83,8 +81,8 @@
                                         edgeBias : 0.2,
                                         centerBias: 0.7,
                                         power: 3.0,
-                                        edgeColor: {r: 1.0, g: 1.0, b: 1.0},
-                                        centerColor: {r: 0.0, g: 0.0, b: 0.0},
+                                        edgeColor: {r: 1.0, g: 0.5, b: 0.0},
+                                        centerColor: {r: 0.0, g: 0.0, b: 1.0},
 
                                         nodes: [
 

--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -977,7 +977,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
                 if (emitFresnel) {
                     src.push("float emitFresnel = fresnel(worldEyeVec, SCENEJS_vWorldNormal, SCENEJS_uEmitFresnelEdgeBias, SCENEJS_uEmitFresnelCenterBias, SCENEJS_uEmitFresnelPower);");
-                    src.push("emit *= mix(SCENEJS_uEmitFresnelEdgeColor.r, SCENEJS_uEmitFresnelCenterColor.r, emitFresnel);");
+                    src.push("emitColor.rgb *= mix(SCENEJS_uEmitFresnelEdgeColor.rgb, SCENEJS_uEmitFresnelCenterColor.rgb, emitFresnel);");
                 }
             }
 


### PR DESCRIPTION
It would be more flexible to have the fresnel calculations done on the emitColor, rather than just the emit weight. The emit weight can be emulated by setting one of the fresnel colors to black, and this allows the emit fresnel to go from one color to another.