### PR TITLE
Fix opaque-only render and readPixels

### DIFF
--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -1095,7 +1095,7 @@ SceneJS_Display.prototype._doDrawList = function (params) {
     } else {
 
         // Option to only render opaque objects
-        var len =  (params.opaqueOnly ? this._drawListTransparentIndex: this._drawListLen);
+        var len =  (params.opaqueOnly && this._drawListTransparentIndex >= 0 ? this._drawListTransparentIndex : this._drawListLen);
 
         // Render for draw
         for (var i = 0; i < len; i++) {      // Push opaque rendering chunks

--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -980,7 +980,7 @@ SceneJS_Display.prototype.pick = function (params) {
     return hit;
 };
 
-SceneJS_Display.prototype.readPixels = function (entries, size) {
+SceneJS_Display.prototype.readPixels = function (entries, size, opaqueOnly) {
 
     if (!this._readPixelBuf) {
         this._readPixelBuf = new SceneJS._webgl.RenderBuffer({ canvas: this._canvas });
@@ -990,7 +990,10 @@ SceneJS_Display.prototype.readPixels = function (entries, size) {
 
     this._readPixelBuf.clear();
 
-    this.render({ force: true });
+    this.render({
+        force: true,
+        opaqueOnly: opaqueOnly
+    });
 
     var entry;
     var color;


### PR DESCRIPTION
Fixes a bug in `Display.render()` with parameter `opaqueOnly: true` that caused nothing to be rendered if there were no transparent objects in the scene.

Also fixes a bug in `Display.readPixels()` where a third argument, `opaqueOnly`, was being passed to the method ([e.g.](https://github.com/xeolabs/scenejs/blob/master/src/core/engine.js#L556)), but was being ignored.