### PR TITLE
Fixed pick mode switching

### DIFF
--- a/src/core/display/chunks/programChunk.js
+++ b/src/core/display/chunks/programChunk.js
@@ -38,9 +38,10 @@ SceneJS_ChunkFactory.createChunkType({
 
         if (frameCtx.rayPick) {
             this._pickMode.setValue(1.0);
-
         } else if (frameCtx.regionPick) {
             this._pickMode.setValue(2.0);
+        } else {
+            this._pickMode.setValue(0.0);
         }
 
         if (this._depthModePick) {


### PR DESCRIPTION
This fix ensures that picking can properly go back to the default object picking mode after having been set to region or ray picking mode.