### PR TITLE
Fixed hashing and precision of region maps

### DIFF
--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -404,7 +404,8 @@ SceneJS_Display.prototype.buildObject = function (objectId) {
         this.fresnel.hash,
         this.cubemap.hash,
         this.lights.hash,
-        this.flags.hash
+        this.flags.hash,
+        this.regionMap.hash
     ]).join(";");
 
     if (!object.program || hash != object.hash) {

--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -1042,7 +1042,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
             // Region map highlighting
 
             src.push("vec3 regionColor = texture2D(SCENEJS_uRegionMapSampler, vec2(SCENEJS_vRegionMapUV.s, 1.0 - SCENEJS_vRegionMapUV.t)).rgb;");
-            src.push("float tolerance = 0.03;");
+            src.push("float tolerance = 0.01;");
             src.push("float colorDelta = dot(abs(SCENEJS_uRegionMapHighlightColor - regionColor), vec3(1.0));");
             src.push("if (colorDelta < tolerance) {");
             src.push("  fragColor.rgb *= SCENEJS_uRegionMapHighlightFactor;");

--- a/src/core/scene/regionMap.js
+++ b/src/core/scene/regionMap.js
@@ -10,7 +10,7 @@ new (function () {
         stateId: SceneJS._baseStateId++,
         empty: true,
         texture: null,
-        highlightColor:[ 1.0, 1.0, 1.0 ],
+        highlightColor:[ -1.0, -1.0, -1.0 ],    // Highlight off by default
         highlightFactor:[ 1.5, 1.5, 0.0 ],
         hash: ""
     };
@@ -86,6 +86,8 @@ new (function () {
 
             this.setHighlightColor(params.highlightColor);
             this.setHighlightFactor(params.highlightFactor);
+
+            this._core.hash = "reg";
         }
     };
 


### PR DESCRIPTION
- Fixes the fact that regionMap nodes weren't included in the display program hash.
- Sets default regionMap highlight color to a non-color value, so it doesn't highlight anything on load.
- Reduces tolerance in the region color test, because I found it leading to errors (it was allowing for ~8/255 error, now allows ~3/255 error, which I think should be enough).