### PR TITLE
Fix region map texture interpolation and region check

### DIFF
--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -1043,8 +1043,8 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
             src.push("vec3 regionColor = texture2D(SCENEJS_uRegionMapSampler, vec2(SCENEJS_vRegionMapUV.s, 1.0 - SCENEJS_vRegionMapUV.t)).rgb;");
             src.push("float tolerance = 0.01;");
-            src.push("float colorDelta = dot(abs(SCENEJS_uRegionMapHighlightColor - regionColor), vec3(1.0));");
-            src.push("if (colorDelta < tolerance) {");
+            src.push("vec3 colorDelta = abs(SCENEJS_uRegionMapHighlightColor - regionColor);");
+            src.push("if (max(colorDelta.x, max(colorDelta.y, colorDelta.z)) < tolerance) {");
             src.push("  fragColor.rgb *= SCENEJS_uRegionMapHighlightFactor;");
             src.push("}");
         }

--- a/src/core/scene/regionMap.js
+++ b/src/core/scene/regionMap.js
@@ -155,8 +155,8 @@ new (function () {
 
         this._core.texture = new SceneJS._webgl.Texture2D(gl, {
             texture: texture, // WebGL texture object
-            minFilter: this._getGLOption("minFilter", gl.LINEAR_MIPMAP_NEAREST),
-            magFilter: this._getGLOption("magFilter", gl.LINEAR),
+            minFilter: this._getGLOption("minFilter", gl.NEAREST_MIPMAP_NEAREST),  // Don't want any interpolation
+            magFilter: this._getGLOption("magFilter", gl.NEAREST),
             wrapS: this._getGLOption("wrapS", gl.REPEAT),
             wrapT: this._getGLOption("wrapT", gl.REPEAT),
             isDepth: this._getOption(this._core.isDepth, false),


### PR DESCRIPTION
- Change the texture interpolation on region maps to nearest neighbour to avoid errors due to interpolation.
- Changed the region check to function per channel instead of on the sum.