### PR TITLE
Arbitrary data can now be associated with regions.

### DIFF
--- a/examples/picking_regions.html
+++ b/examples/picking_regions.html
@@ -82,7 +82,7 @@
                         // Colors of the texture define regions of the surface
                         src: 'textures/terrainHeightMap.png',
 
-                        // Arbitrary data can be associate with a particular region
+                        // Arbitrary data can be associated with a particular region
                         regionData: {
                             "0.1,0.1,0.1": {
                                 message: "Getting started!"

--- a/examples/picking_regions.html
+++ b/examples/picking_regions.html
@@ -78,7 +78,25 @@
                     {
                         type: "regionMap",
                         id: "myRegionMap",
+
+                        // Colors of the texture define regions of the surface
                         src: 'textures/terrainHeightMap.png',
+
+                        // Arbitrary data can be associate with a particular region
+                        regionData: {
+                            "0.1,0.1,0.1": {
+                                message: "Getting started!"
+                            },
+                            "0.33333,0.33333,0.33333": {
+                                message: "Halfway there!"
+                            },
+                            "0.5,0.5,0.5": {
+                                message: "Almost!"
+                            },
+                            "0.66666,0.66666,0.66666": {
+                                message: "Made it!"
+                            },
+                        },
                         highlightFactor: {
                             r: 1.5, g: 1.5, b: 0.0
                         },
@@ -149,7 +167,7 @@
     scene.on("pick",
             function (hit) {
 
-                info.innerHTML = "Pick hit: " + JSON.stringify(hit);
+                info.innerHTML = "Message: " + (hit.regionData.message || "(None)");
 
                 var color = hit.color; // Eg. { r: 0.3, g: 0.5, b: 1.0 }
                 var canvasPos = hit.canvasPos;

--- a/src/core/display/chunks/regionMapChunk.js
+++ b/src/core/display/chunks/regionMapChunk.js
@@ -36,6 +36,8 @@ SceneJS_ChunkFactory.createChunkType({
 
         if (texture) {
 
+            frameCtx.regionData = this.core.regionData;
+
             frameCtx.textureUnit = 0;
 
             this.program.pick.bindTexture(this._uRegionMapSampler, texture, frameCtx.textureUnit++);

--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -289,7 +289,8 @@ var SceneJS_Display = function (cfg) {
      * the render, such as pick hits
      */
     this._frameCtx = {
-        pickNames: [], // Pick names of objects hit during pick render
+        pickNames: [], // Pick names of objects hit during pick render,
+        regionData: {},
         canvas: this._canvas,           // The canvas
         VAO: null                       // Vertex array object extension
     };
@@ -923,8 +924,27 @@ SceneJS_Display.prototype.pick = function (params) {
 
         // Region picking
 
+        var regionColor = {r: pix[0] / 255, g: pix[1] / 255, b: pix[2] / 255, a: pix[3] / 255};
+        var regionData = this._frameCtx.regionData;
+        var data = {};
+        var tolerance = 0.01;
+
+        for (var color in regionData) {
+            var delta = color.split(",");
+            delta[0] = Math.abs(regionColor.r - parseFloat(delta[0]));
+            delta[1] = Math.abs(regionColor.g - parseFloat(delta[1]));
+            delta[2] = Math.abs(regionColor.b - parseFloat(delta[2]));
+            delta[3] = Math.abs(regionColor.a - parseFloat(delta[3] || 1));
+
+            if (Math.max(delta[0], delta[1], delta[2], delta[3]) < tolerance) {
+                data = regionData[color];
+            }
+
+        }
+
         return {
-            color: {r: pix[0] / 255, g: pix[1] / 255, b: pix[2] / 255, a: pix[3] / 255},
+            color: regionColor,
+            regionData: data,
             canvasPos: [canvasX, canvasY]
         };
     }

--- a/src/core/scene/regionMap.js
+++ b/src/core/scene/regionMap.js
@@ -12,6 +12,7 @@ new (function () {
         texture: null,
         highlightColor:[ -1.0, -1.0, -1.0 ],    // Highlight off by default
         highlightFactor:[ 1.5, 1.5, 0.0 ],
+        regionData: {},
         hash: ""
     };
 
@@ -86,6 +87,7 @@ new (function () {
 
             this.setHighlightColor(params.highlightColor);
             this.setHighlightFactor(params.highlightFactor);
+            this.setRegionData(params.regionData);
 
             this._core.hash = "reg";
         }
@@ -245,6 +247,11 @@ new (function () {
             color.b != undefined && color.b != null ? color.b : defaultHighlightFactor[2]
         ] : defaultCore.highlightFactor;
         this._engine.display.imageDirty = true;
+        return this;
+    };
+
+    SceneJS.RegionMap.prototype.setRegionData = function (data) {
+        this._core.regionData = data ? data : defaultCore.regionData;
         return this;
     };
 


### PR DESCRIPTION
I think you'll like this...

Basically, a region map can now associate arbitrary data with its regions. That data will be returned as part of the hit event for a region pick. See the picking_regions example for details on how to use it. 