### PR TITLE
Updated region data format and picking bg always transparent black

### DIFF
--- a/examples/picking_regions.html
+++ b/examples/picking_regions.html
@@ -83,20 +83,48 @@
                         src: 'textures/terrainHeightMap.png',
 
                         // Arbitrary data can be associated with a particular region
-                        regionData: {
-                            "0.1,0.1,0.1": {
-                                message: "Getting started!"
+                        regionData: [
+                            {
+                                color: {
+                                    r: 0.1,
+                                    g: 0.1,
+                                    b: 0.1
+                                },
+                                data: {
+                                    message: "Getting started!"
+                                }
                             },
-                            "0.33333,0.33333,0.33333": {
-                                message: "Halfway there!"
+                            {
+                                color: {
+                                    r: 0.33333,
+                                    g: 0.33333,
+                                    b: 0.33333
+                                },
+                                data: {
+                                    message: "Halfway there!"
+                                }
                             },
-                            "0.5,0.5,0.5": {
-                                message: "Almost!"
+                            {
+                                color: {
+                                    r: 0.5,
+                                    g: 0.5,
+                                    b: 0.5
+                                },
+                                data: {
+                                    message: "Almost!"
+                                }
                             },
-                            "0.66666,0.66666,0.66666": {
-                                message: "Made it!"
+                            {
+                                color: {
+                                    r: 0.6666,
+                                    g: 0.6666,
+                                    b: 0.6666
+                                },
+                                data: {
+                                    message: "Made it!"
+                                }
                             },
-                        },
+                        ],
                         highlightFactor: {
                             r: 1.5, g: 1.5, b: 0.0
                         },

--- a/src/core/scene/regionMap.js
+++ b/src/core/scene/regionMap.js
@@ -12,7 +12,7 @@ new (function () {
         texture: null,
         highlightColor:[ -1.0, -1.0, -1.0 ],    // Highlight off by default
         highlightFactor:[ 1.5, 1.5, 0.0 ],
-        regionData: {},
+        regionData: [],
         hash: ""
     };
 


### PR DESCRIPTION
Update [regionData format](https://github.com/tsherif/scenejs/blob/regionmap-updates/examples/picking_regions.html#L86) to something a little more pleasant and performant.

Also ensure that the background is transparent black for picking ([here](https://github.com/tsherif/scenejs/blob/regionmap-updates/src/core/display/display.js#L1127)). Can you make sure this is valid? It makes it easier to verify misses (especially for region picking), but I wasn't sure if there might be be a reason you want the ambient color on for picking.