### PR TITLE
Reduce the number of varyings used in the rendering shaders

### DIFF
--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -393,13 +393,13 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         if (tangents) {
 
-            src.push("SCENEJS_vTangent = SCENEJS_aTangent.xyz;");
-
             // Compute tangent-bitangent-normal matrix
 
             src.push("vec3 tangent = normalize((SCENEJS_uVNMatrix * SCENEJS_uMNMatrix * SCENEJS_aTangent).xyz);");
             src.push("vec3 bitangent = cross(SCENEJS_vViewNormal, tangent);");
             src.push("mat3 TBM = mat3(tangent, bitangent, SCENEJS_vViewNormal);");
+
+            src.push("SCENEJS_vTangent = tangent;");
         }
 
         src.push("SCENEJS_vViewEyeVec = ((SCENEJS_uVMatrix * vec4(SCENEJS_uWorldEye, 0.0)).xyz  - viewVertex.xyz);");
@@ -622,7 +622,6 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         if (normals) {
 
-            src.push("uniform mat4 SCENEJS_uMNMatrix;");      // Model normal matrix
             src.push("uniform mat4 SCENEJS_uVNMatrix;"); 
             src.push("varying vec3 SCENEJS_vViewNormal;");
 
@@ -894,7 +893,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
                 // Compute tangent-bitangent-normal matrix
 
-                src.push("vec3 tangent = normalize((SCENEJS_uVNMatrix * SCENEJS_uMNMatrix * vec4(normalize(SCENEJS_vTangent), 0.0)).xyz);");
+                src.push("vec3 tangent = normalize(SCENEJS_vTangent);");
                 src.push("vec3 bitangent = cross(SCENEJS_vViewNormal, tangent);");
                 src.push("mat3 TBM = mat3(tangent, bitangent, SCENEJS_vViewNormal);");
             }

--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -265,30 +265,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
             if (tangents) {
                 src.push("attribute vec4 SCENEJS_aTangent;");
-            }
-
-            for (var i = 0; i < states.lights.lights.length; i++) {
-
-                var light = states.lights.lights[i];
-
-                if (light.mode == "ambient") {
-                    continue;
-                }
-
-                if (light.mode == "dir") {
-                    src.push("uniform vec3 SCENEJS_uLightDir" + i + ";");
-                }
-
-                if (light.mode == "point") {
-                    src.push("uniform vec3 SCENEJS_uLightPos" + i + ";");
-                }
-
-                if (light.mode == "spot") {
-                    src.push("uniform vec3 SCENEJS_uLightPos" + i + ";");
-                }
-
-                // Vector from vertex to light, packaged with the pre-computed length of that vector
-                src.push("varying vec4 SCENEJS_vViewLightVecAndDist" + i + ";");
+                src.push("varying   vec3 SCENEJS_vTangent;");
             }
         }
 
@@ -401,97 +378,13 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         if (tangents) {
 
+            src.push("SCENEJS_vTangent = SCENEJS_aTangent.xyz;");
+
             // Compute tangent-bitangent-normal matrix
 
             src.push("vec3 tangent = normalize((SCENEJS_uVNMatrix * SCENEJS_uMNMatrix * SCENEJS_aTangent).xyz);");
             src.push("vec3 bitangent = cross(SCENEJS_vViewNormal, tangent);");
             src.push("mat3 TBM = mat3(tangent, bitangent, SCENEJS_vViewNormal);");
-        }
-
-        src.push("  vec3 tmpVec3;");
-
-        if (normals) {
-
-            for (var i = 0; i < states.lights.lights.length; i++) {
-
-                light = states.lights.lights[i];
-
-                if (light.mode == "ambient") {
-                    continue;
-                }
-
-                if (light.mode == "dir") {
-
-                    // Directional light
-
-                    if (light.space == "world") {
-
-                        // World space light
-
-                        src.push("tmpVec3 = normalize(SCENEJS_uLightDir" + i + ");");
-
-                        // Transform to View space
-                        src.push("tmpVec3 = vec3(SCENEJS_uVMatrix * vec4(tmpVec3, 0.0)).xyz;");
-
-                        if (tangents) {
-
-                            // Transform to Tangent space
-                            src.push("tmpVec3 *= TBM;");
-                        }
-
-                    } else {
-
-                        // View space light
-
-                        src.push("tmpVec3 = normalize(SCENEJS_uLightDir" + i + ");");
-
-                        if (tangents) {
-
-                            // Transform to Tangent space
-                            src.push("tmpVec3 *= TBM;");
-                        }
-                    }
-
-                    // Output
-                    src.push("SCENEJS_vViewLightVecAndDist" + i + " = vec4(-tmpVec3, 0.0);");
-                }
-
-                if (light.mode == "point") {
-
-                    // Positional light
-
-                    if (light.space == "world") {
-
-                        // World space
-
-                        src.push("tmpVec3 = SCENEJS_uLightPos" + i + " - worldVertex.xyz;"); // Vector from World coordinate to light pos
-
-                        // Transform to View space
-                        src.push("tmpVec3 = vec3(SCENEJS_uVMatrix * vec4(tmpVec3, 0.0)).xyz;");
-
-                        if (tangents) {
-
-                            // Transform to Tangent space
-                            src.push("tmpVec3 *= TBM;");
-                        }
-
-                    } else {
-
-                        // View space
-
-                        src.push("tmpVec3 = SCENEJS_uLightPos" + i + ".xyz - viewVertex.xyz;"); // Vector from View coordinate to light pos
-
-                        if (tangents) {
-
-                            // Transform to tangent space
-                            src.push("tmpVec3 *= TBM;");
-                        }
-                    }
-
-                    // Output
-                    src.push("SCENEJS_vViewLightVecAndDist" + i + " = vec4(tmpVec3, length( SCENEJS_uLightPos" + i + " - worldVertex.xyz));");
-                }
-            }
         }
 
         src.push("SCENEJS_vViewEyeVec = ((SCENEJS_uVMatrix * vec4(SCENEJS_uWorldEye, 0.0)).xyz  - viewVertex.xyz);");
@@ -567,6 +460,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         src.push("precision " + floatPrecision + " float;");
 
+        src.push("uniform mat4 SCENEJS_uVMatrix;");
 
         if (clipping || normals) {
             src.push("varying vec4 SCENEJS_vWorldVertex;");             // World-space vertex
@@ -612,8 +506,6 @@ var SceneJS_ProgramSourceFactory = new (function () {
         }
 
         if (normals && cubeMapping) {
-
-            src.push("uniform mat4 SCENEJS_uVNMatrix;");
 
             var layer;
             for (var i = 0, len = states.cubemap.layers.length; i < len; i++) {
@@ -713,8 +605,14 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         if (normals) {
 
+            src.push("uniform mat4 SCENEJS_uMNMatrix;");      // Model normal matrix
+            src.push("uniform mat4 SCENEJS_uVNMatrix;"); 
             src.push("varying vec3 SCENEJS_vWorldNormal;");
             src.push("varying vec3 SCENEJS_vViewNormal;");
+
+            if (tangents) {
+                src.push("varying vec3 SCENEJS_vTangent;");
+            }
 
             var light;
             for (var i = 0; i < states.lights.lights.length; i++) {
@@ -723,10 +621,19 @@ var SceneJS_ProgramSourceFactory = new (function () {
                     continue;
                 }
                 src.push("uniform vec3  SCENEJS_uLightColor" + i + ";");
+                
+                if (light.mode == "dir") {
+                    src.push("uniform vec3 SCENEJS_uLightDir" + i + ";");
+                }
+
                 if (light.mode == "point") {
                     src.push("uniform vec3  SCENEJS_uLightAttenuation" + i + ";");
+                    src.push("uniform vec3 SCENEJS_uLightPos" + i + ";");
                 }
-                src.push("varying vec4  SCENEJS_vViewLightVecAndDist" + i + ";");         // Vector from light to vertex
+
+                if (light.mode == "spot") {
+                    src.push("uniform vec3 SCENEJS_uLightPos" + i + ";");
+                }  
             }
         }
 
@@ -960,6 +867,15 @@ var SceneJS_ProgramSourceFactory = new (function () {
             src.push("  float   dotN;");
             src.push("  float   lightDist;");
 
+            if (tangents) {
+
+                // Compute tangent-bitangent-normal matrix
+
+                src.push("vec3 tangent = normalize((SCENEJS_uVNMatrix * SCENEJS_uMNMatrix * vec4(normalize(SCENEJS_vTangent), 0.0)).xyz);");
+                src.push("vec3 bitangent = cross(SCENEJS_vViewNormal, tangent);");
+                src.push("mat3 TBM = mat3(tangent, bitangent, SCENEJS_vViewNormal);");
+            }
+
             var light;
 
             for (var i = 0, len = states.lights.lights.length; i < len; i++) {
@@ -969,14 +885,39 @@ var SceneJS_ProgramSourceFactory = new (function () {
                     continue;
                 }
 
-                src.push("viewLightVec = SCENEJS_vViewLightVecAndDist" + i + ".xyz;");
-
                 if (light.mode == "point") {
+
+                    if (light.space == "world") {
+
+                        // World space
+
+                        src.push("viewLightVec = SCENEJS_uLightPos" + i + " - SCENEJS_vWorldVertex.xyz;"); // Vector from World coordinate to light pos
+
+                        // Transform to View space
+                        src.push("viewLightVec = vec3(SCENEJS_uVMatrix * vec4(viewLightVec, 0.0)).xyz;");
+
+                        if (tangents) {
+
+                            // Transform to Tangent space
+                            src.push("viewLightVec *= TBM;");
+                        }
+
+                    } else {
+
+                        // View space
+
+                        src.push("viewLightVec = SCENEJS_uLightPos" + i + ".xyz - SCENEJS_vViewVertex.xyz;"); // Vector from View coordinate to light pos
+
+                        if (tangents) {
+
+                            // Transform to tangent space
+                            src.push("viewLightVec *= TBM;");
+                        }
+                    }
 
                     src.push("dotN = max(dot(viewNormalVec, normalize(viewLightVec)), 0.0);");
 
-
-                    src.push("lightDist = SCENEJS_vViewLightVecAndDist" + i + ".w;");
+                    src.push("lightDist = length( SCENEJS_uLightPos" + i + " - SCENEJS_vWorldVertex.xyz);");
 
                     src.push("attenuation = 1.0 - (" +
                         "  SCENEJS_uLightAttenuation" + i + "[0] + " +
@@ -994,6 +935,36 @@ var SceneJS_ProgramSourceFactory = new (function () {
                 }
 
                 if (light.mode == "dir") {
+
+                    if (light.space == "world") {
+
+                        // World space light
+
+                        src.push("viewLightVec = normalize(SCENEJS_uLightDir" + i + ");");
+
+                        // Transform to View space
+                        src.push("viewLightVec = vec3(SCENEJS_uVMatrix * vec4(viewLightVec, 0.0)).xyz;");
+
+                        if (tangents) {
+
+                            // Transform to Tangent space
+                            src.push("viewLightVec *= TBM;");
+                        }
+
+                    } else {
+
+                        // View space light
+
+                        src.push("viewLightVec = normalize(SCENEJS_uLightDir" + i + ");");
+
+                        if (tangents) {
+
+                            // Transform to Tangent space
+                            src.push("viewLightVec *= TBM;");
+                        }
+                    }
+
+                    src.push("viewLightVec = -viewLightVec;");
 
                     src.push("dotN = max(dot(viewNormalVec, normalize(viewLightVec)), 0.0);");
 


### PR DESCRIPTION
SceneJS seems to easily hit the limit on varyings in low-powered devices (iOS in particular, which only has 8). To remedy this I've done the following:
- Moved all lighting calculations to the fragment shader to eliminate use of the per-light `SCENEJS_vViewLightVecAndDist ` variables. Though this might bring up some performance concerns, I tested it against the performance benchmark examples and didn't see a significant change.
- Only insert `SCENEJS_vWorldNormal ` into the shaders if a fresnel is active, since that's the only functionality that uses it. 