### PR TITLE
Restore updates that went missing from xeolabs/scenejs/master

### DIFF
--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -1032,7 +1032,7 @@ SceneJS_Display.prototype.pick = function (params) {
     return hit;
 };
 
-SceneJS_Display.prototype.readPixels = function (entries, size) {
+SceneJS_Display.prototype.readPixels = function (entries, size, opaqueOnly) {
 
     if (!this._readPixelBuf) {
         this._readPixelBuf = new SceneJS._webgl.RenderBuffer({canvas: this._canvas});
@@ -1042,7 +1042,10 @@ SceneJS_Display.prototype.readPixels = function (entries, size) {
 
     this._readPixelBuf.clear();
 
-    this.render({force: true});
+    this.render({
+        force: true,
+        opaqueOnly: opaqueOnly
+    });
 
     var entry;
     var color;
@@ -1146,7 +1149,7 @@ SceneJS_Display.prototype._doDrawList = function (params) {
     } else {
 
         // Option to only render opaque objects
-        var len = (params.opaqueOnly ? this._drawListTransparentIndex : this._drawListLen);
+        var len = (params.opaqueOnly && this._drawListTransparentIndex >= 0 ? this._drawListTransparentIndex : this._drawListLen);
 
         // Render for draw
         for (var i = 0; i < len; i++) {      // Push opaque rendering chunks

--- a/src/core/scene/lights.js
+++ b/src/core/scene/lights.js
@@ -97,7 +97,7 @@
 
     SceneJS.Lights.prototype._initLight = function (index, cfg) {
 
-        var light = [];
+        var light = {};
         this._core.lights[index] = light;
 
         var mode = cfg.mode || "dir";


### PR DESCRIPTION
This PR contains the following updates that went missing from master:
- Lighting calculations moved completely to fragment shader to avoid excessive use of varyings on limited devices
- Bug fix for opaque-only rendering
- Lights represented by objects instead of arrays