### PR TITLE
New "render" event

### DIFF
--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -583,6 +583,9 @@ SceneJS_Display.prototype.render = function (params) {
     }
 
     if (this.imageDirty || params.force) {
+        SceneJS_events.fireEvent(SceneJS_events.RENDER, {
+            forced: !!params.force
+        });
         this._doDrawList({ // Render, no pick
             clear: (params.clear !== false), // Clear buffers by default
             opaqueOnly: params.opaqueOnly

--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -114,6 +114,10 @@ var SceneJS_Engine = function (json, options) {
         this.scene.addNodes(nodes); // then create sub-nodes
     }
 
+    SceneJS_events.addListener(SceneJS_events.RENDER, function(event) {
+        self.scene.publish("render", event);
+    });
+
     this.canvas.canvas.addEventListener(// WebGL context lost
         "webglcontextlost",
         function (event) {

--- a/src/core/events.js
+++ b/src/core/events.js
@@ -12,6 +12,7 @@ var SceneJS_events = new (function () {
     this.OBJECT_COMPILING = 6;
     this.WEBGL_CONTEXT_LOST = 7;
     this.WEBGL_CONTEXT_RESTORED = 8;
+    this.RENDER = 9;
 
     /* Priority queue for each type of event
      */


### PR DESCRIPTION
I think it would be useful to have an event that fires just once when SceneJS is planning to render a frame, even if that rendering is forced. We currently only have [tick](https://github.com/tsherif/scenejs/blob/render-event/src/core/engine.js#L492) which is only triggered in the regular animation loop, and [rendering/rendered](https://github.com/tsherif/scenejs/blob/render-event/src/core/engine.js#L332) which are called for each pass of a multipass algorithm.

The only issue I see with this update is the naming, in that it the differences between `render`, `rendering` and `rendered` will be unclear from the names. If you're ok with breaking back-compatibility, we could rename the latter two to `renderingPass` and `renderedPass`, or we could rename the new event to `renderFrame`. Let me know if you have any thoughts on that.