### PR TITLE
Texture unit bookkeeping and WebGL info

### DIFF
--- a/src/core/canvas.js
+++ b/src/core/canvas.js
@@ -93,8 +93,6 @@ SceneJS_Canvas.prototype.initWebGL = function () {
             SceneJS.errors.WEBGL_NOT_SUPPORTED,
             'Failed to get a WebGL context');
     }
-
-    this.UINT_INDEX_ENABLED = !!this.gl.getExtension("OES_element_index_uint");
 };
 
 

--- a/src/core/display/chunks/cubemapChunk.js
+++ b/src/core/display/chunks/cubemapChunk.js
@@ -25,16 +25,15 @@ SceneJS_ChunkFactory.createChunkType({
             for (var i = 0, len = layers.length; i < len; i++) {
                 layer = layers[i];
                 if (this._uCubeMapSampler[i] && layer.texture) {
-                    draw.bindTexture(this._uCubeMapSampler[i], layer.texture, frameCtx.textureUnit++);
+
+                    draw.bindTexture(this._uCubeMapSampler[i], layer.texture, frameCtx.textureUnit);
+                    frameCtx.textureUnit = (frameCtx.textureUnit + 1) % SceneJS.WEBGL_INFO.MAX_TEXTURE_UNITS;
+
                     if (this._uCubeMapIntensity[i]) {
                         this._uCubeMapIntensity[i].setValue(layer.intensity);
                     }
                 }
             }
-        }
-
-        if (frameCtx.textureUnit > 10) { // TODO: Find how many textures allowed
-            frameCtx.textureUnit = 0;
         }
     }
 });

--- a/src/core/display/chunks/regionMapChunk.js
+++ b/src/core/display/chunks/regionMapChunk.js
@@ -14,11 +14,9 @@ SceneJS_ChunkFactory.createChunkType({
 
         if (texture) {
 
-            this.program.draw.bindTexture(this._uRegionMapSampler, texture, frameCtx.textureUnit++);
+            this.program.draw.bindTexture(this._uRegionMapSampler, texture, frameCtx.textureUnit);
+            frameCtx.textureUnit = (frameCtx.textureUnit + 1) % SceneJS.WEBGL_INFO.MAX_TEXTURE_UNITS;
 
-            if (frameCtx.textureUnit > 10) { // TODO: Find how many textures allowed
-                frameCtx.textureUnit = 0;
-            }
         }
 
         if (this._uRegionMapHighlightColor) {
@@ -40,11 +38,9 @@ SceneJS_ChunkFactory.createChunkType({
 
             frameCtx.textureUnit = 0;
 
-            this.program.pick.bindTexture(this._uRegionMapSampler, texture, frameCtx.textureUnit++);
+            this.program.pick.bindTexture(this._uRegionMapSampler, texture, frameCtx.textureUnit);
+            frameCtx.textureUnit = (frameCtx.textureUnit + 1) % SceneJS.WEBGL_INFO.MAX_TEXTURE_UNITS;
 
-            if (frameCtx.textureUnit > 10) { // TODO: Find how many textures allowed
-                frameCtx.textureUnit = 0;
-            }
         }
     }
 });

--- a/src/core/display/chunks/textureChunk.js
+++ b/src/core/display/chunks/textureChunk.js
@@ -45,7 +45,8 @@ SceneJS_ChunkFactory.createChunkType({
 
                 if (this._uTexSampler[i] && layer.texture) {    // Lazy-loads
 
-                    draw.bindTexture(this._uTexSampler[i], layer.texture, frameCtx.textureUnit++);
+                    draw.bindTexture(this._uTexSampler[i], layer.texture, frameCtx.textureUnit);
+                    frameCtx.textureUnit = (frameCtx.textureUnit + 1) % SceneJS.WEBGL_INFO.MAX_TEXTURE_UNITS;
 
                     if (layer._matrixDirty && layer.buildMatrix) {
                         layer.buildMatrix.call(layer);
@@ -65,8 +66,5 @@ SceneJS_ChunkFactory.createChunkType({
             }
         }
 
-        if (frameCtx.textureUnit > 10) { // TODO: Find how many textures allowed
-            frameCtx.textureUnit = 0;
-        }
     }
 });

--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -1118,7 +1118,7 @@ SceneJS_Display.prototype._doDrawList = function (params) {
     frameCtx.aspect = this._canvas.canvas.width / this._canvas.canvas.height;
 
     // The extensions needs to be re-queried in case the context was lost and has been recreated.
-    if (this._canvas.UINT_INDEX_ENABLED) {
+    if (SceneJS.WEBGL_INFO.SUPPORTED_EXTENSIONS["OES_element_index_uint"]) {
         gl.getExtension("OES_element_index_uint");
     }
 

--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -95,10 +95,8 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         var clipping = states.clips.clips.length > 0;
 
-        var floatPrecision = getFSFloatPrecision(states._canvas.gl);
-
         var src = [
-            "precision " + floatPrecision + " float;"
+            "precision " + SceneJS.WEBGL_INFO.FS_MAX_FLOAT_PRECISION + " float;"
         ];
 
         src.push("varying vec4 SCENEJS_vWorldVertex;");
@@ -471,11 +469,9 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         var fresnel = diffuseFresnel || specularFresnel || alphaFresnel || reflectFresnel || emitFresnel || fragmentFresnel;
 
-        var floatPrecision = getFSFloatPrecision(states._canvas.gl);
-
         var src = ["\n"];
 
-        src.push("precision " + floatPrecision + " float;");
+        src.push("precision " + SceneJS.WEBGL_INFO.FS_MAX_FLOAT_PRECISION + " float;");
 
         src.push("uniform mat4 SCENEJS_uVMatrix;");
 
@@ -1094,22 +1090,6 @@ var SceneJS_ProgramSourceFactory = new (function () {
             }
         }
         return false;
-    }
-
-    function getFSFloatPrecision(gl) {
-        if (!gl.getShaderPrecisionFormat) {
-            return "mediump";
-        }
-
-        if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision > 0) {
-            return "highp";
-        }
-
-        if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.MEDIUM_FLOAT).precision > 0) {
-            return "mediump";
-        }
-
-        return "lowp";
     }
 
 })

--- a/src/core/scene/geometry.js
+++ b/src/core/scene/geometry.js
@@ -51,7 +51,7 @@ new (function () {
 
         var primitive = data.primitive || "triangles";
         var core = this._core;
-        var IndexArrayType = this._engine.canvas.UINT_INDEX_ENABLED ? Uint32Array : Uint16Array;
+        var IndexArrayType = SceneJS.WEBGL_INFO.SUPPORTED_EXTENSIONS["OES_element_index_uint"] ? Uint32Array : Uint16Array;
 
         core.primitive = this._getPrimitiveType(primitive);
 

--- a/src/core/scenejs.js
+++ b/src/core/scenejs.js
@@ -24,9 +24,16 @@ var SceneJS = new (function () {
     this._engineIds = new SceneJS_Map();
 
     this.WEBGL_INFO = (function() {
-        var info = {};
+        var info = {
+            WEBGL: false
+        };
 
         var canvas = document.createElement("canvas");
+
+        if (!canvas) {
+            return info;
+        }
+
         var gl = canvas.getContext("webgl", { antialias: true }) || document.getContext("experimental-webgl", { antialias: true });
 
         info.WEBGL = !!gl;

--- a/src/core/scenejs.js
+++ b/src/core/scenejs.js
@@ -23,6 +23,51 @@ var SceneJS = new (function () {
 
     this._engineIds = new SceneJS_Map();
 
+    this.WEBGL_INFO = (function() {
+        var info = {};
+
+        var canvas = document.createElement("canvas");
+        var gl = canvas.getContext("webgl", { antialias: true }) || document.getContext("experimental-webgl", { antialias: true });
+
+        info.WEBGL = !!gl;
+
+        if (!info.WEBGL) {
+            return info;
+        }
+
+        info.ANTIALIAS = gl.getContextAttributes().antialias;
+
+        if (gl.getShaderPrecisionFormat) {
+            if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.HIGH_FLOAT).precision > 0) {
+                info.FS_MAX_FLOAT_PRECISION = "highp";
+            } else if (gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.MEDIUM_FLOAT).precision > 0) {
+                info.FS_MAX_FLOAT_PRECISION = "mediump";
+            } else {
+                info.FS_MAX_FLOAT_PRECISION = "lowp";
+            }
+        } else {
+            info.FS_MAX_FLOAT_PRECISION = "mediump";
+        }
+
+        info.DEPTH_BUFFER_BITS = gl.getParameter(gl.DEPTH_BITS);
+        info.MAX_TEXTURE_SIZE = gl.getParameter(gl.MAX_TEXTURE_SIZE);
+        info.MAX_CUBE_MAP_SIZE = gl.getParameter(gl.MAX_CUBE_MAP_TEXTURE_SIZE);
+        info.MAX_RENDERBUFFER_SIZE = gl.getParameter(gl.MAX_RENDERBUFFER_SIZE);
+        info.MAX_TEXTURE_UNITS =  gl.getParameter(gl.MAX_COMBINED_TEXTURE_IMAGE_UNITS);
+        info.MAX_VERTEX_ATTRIBS = gl.getParameter(gl.MAX_VERTEX_ATTRIBS);
+        info.MAX_VERTEX_UNIFORM_VECTORS = gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS);
+        info.MAX_FRAGMENT_UNIFORM_VECTORS = gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS);
+        info.MAX_VARYING_VECTORS = gl.getParameter(gl.MAX_VARYING_VECTORS);
+
+        info.SUPPORTED_EXTENSIONS = {};
+
+        gl.getSupportedExtensions().forEach(function(ext) {
+            info.SUPPORTED_EXTENSIONS[ext] = true;
+        });
+
+        return info;
+    })();
+
 
     /**
      * Publishes to a topic.


### PR DESCRIPTION
SceneJS was assuming that the WebGL context always has at least 10 texture units available, which is incorrect on iOS, for example, [which only has 8](http://codeflow.org/entries/2014/jun/08/some-issues-with-apples-ios-webgl-implementation/).

This update solves the problem in two steps:
- Creates a `SceneJS.WEBGL_INFO` object that stores useful information about the client's WebGL capabilities (max texture units and size, number of varyings and uniforms, shader precision, etc).
- Use `SceneJS.WEBGL_INFO.MAX_TEXTURE_UNITS` to properly cycle through available texture units without going out of bounds.