### PR TITLE
Fixed child nodes publish memory leak when parent is destroyed

### DIFF
--- a/src/core/scene/node.js
+++ b/src/core/scene/node.js
@@ -1378,8 +1378,11 @@ SceneJS.Node.prototype._destroyTree = function () {
 
     this._engine.destroyNode(this); // Release node object
 
+    var childNode;
     for (var i = 0, len = this.nodes.length; i < len; i++) {
-        this.nodes[i]._destroyTree();
+        childNode = this.nodes[i];
+        this._engine.scene.unpublish("nodes/" + childNode.id);
+        childNode._destroyTree();
     }
 };
 


### PR DESCRIPTION
This recursively unpublishes child nodes 'nodes/{node id}' topic from the scene node, when their parent is destroyed. Without it, reference to child nodes was kept in scene's topics array, preventing them from being removed by garbage collector.