### PR TITLE
Fixed modelXFormStack memory leak in pop method

### DIFF
--- a/src/core/scene/modelXFormStack.js
+++ b/src/core/scene/modelXFormStack.js
@@ -208,8 +208,10 @@ var SceneJS_modelXFormStack = new (function () {
     this.pop = function () {
 
         this.top = (--stackLen > 0) ? transformStack[stackLen - 1] : defaultCore;
-
-
+        if (this.top) {
+            this.top.cores.pop();
+            this.top.numCores--;
+        }
         dirty = true;
     };
 


### PR DESCRIPTION
This removes cores from the top core 'cores' array when transformation node is calling modelXFormStack.pop() method. Before they were only being added causing memory leaks. 