### PR TITLE
Fix handling for missed object picks

### DIFF
--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -272,8 +272,8 @@ var SceneJS_Display = function (cfg) {
     this._objectList = [];
     this._objectListLen = 0;
 
-    this._objectPickList = [];
-    this._objectPickListLen = 0;
+    this._objectPickList = [null];  // Index 0 reserved for background (i.e. no pick)
+    this._objectPickListLen = 1;
 
 
     /* The "draw list", comprised collectively of three lists of state chunks belong to visible objects
@@ -691,7 +691,7 @@ SceneJS_Display.prototype._buildDrawList = function () {
     this._drawListLen = 0;
     this._pickDrawListLen = 0;
     this._objectDrawListLen = 0;
-    this._objectPickListLen = 0;
+    this._objectPickListLen = 1;
 
     this._drawListTransparentIndex = -1;
 
@@ -1477,7 +1477,7 @@ SceneJS_Display.prototype._doDrawList = function (params) {
     frameCtx.pickObject = !!params.pickObject;
     frameCtx.pickTriangle = !!params.pickTriangle;
     frameCtx.pickRegion = !!params.pickRegion;
-    frameCtx.pickIndex = 0;
+    frameCtx.pickIndex = 1;
     frameCtx.textureUnit = 0;
     frameCtx.lineWidth = 1;
     frameCtx.transparent = false;
@@ -1494,7 +1494,7 @@ SceneJS_Display.prototype._doDrawList = function (params) {
 
     gl.viewport(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight);
 
-    if (this.transparent || params.pick) {
+    if (this.transparent || frameCtx.picking) {
         gl.clearColor(0, 0, 0, 0);
     } else {
         gl.clearColor(this._ambientColor[0], this._ambientColor[1], this._ambientColor[2], 1.0);


### PR DESCRIPTION
Fixes two bugs in object picking:
1. Background color wasn't properly being set to transparent black for picking, meaning it was impossible to tell when a pick was missed.
2. Pick object indexing was starting at 0, meaning a pick color of transparent black would be ambiguous: could be the first object or the background.