### PR TITLE
Fix bug in modelXFormStack.pop()

### DIFF
--- a/src/core/scene/modelXFormStack.js
+++ b/src/core/scene/modelXFormStack.js
@@ -208,10 +208,8 @@ var SceneJS_modelXFormStack = new (function () {
     this.pop = function () {
 
         this.top = (--stackLen > 0) ? transformStack[stackLen - 1] : defaultCore;
-        if (this.top) {
-            this.top.cores.pop();
-            this.top.numCores--;
-        }
+        transformStack.length = stackLen;  // Release previous top node
+
         dirty = true;
     };
 

--- a/src/core/scene/modelXFormStack.js
+++ b/src/core/scene/modelXFormStack.js
@@ -208,7 +208,7 @@ var SceneJS_modelXFormStack = new (function () {
     this.pop = function () {
 
         this.top = (--stackLen > 0) ? transformStack[stackLen - 1] : defaultCore;
-        transformStack.length = stackLen;  // Release previous top node
+        transformStack[stackLen] = null;  // Release previous top node
 
         dirty = true;
     };


### PR DESCRIPTION
Fixes a bug introduced in 6f43c28. The `modelXFormStack.pop()` method shouldn't destroy the parent-child relationships in the transform hierarchy (the asymmetry between `push` and `pop` is a little confusing). I did add a line, however, to make sure the transformStack doesn't hold on to core references, in case they get destroyed later.

This actually fixes the [transform hierarchy example](http://scenejs.org/examples/index.html#transforms_modelling_hierarchy), which I didn't realize was broken.

This might fix the bug that was being addressed in PR #421.
