### PR TITLE
Fix experimental webgl info

### DIFF
--- a/src/core/scenejs.js
+++ b/src/core/scenejs.js
@@ -34,7 +34,7 @@ var SceneJS = new (function () {
             return info;
         }
 
-        var gl = canvas.getContext("webgl", { antialias: true }) || document.getContext("experimental-webgl", { antialias: true });
+        var gl = canvas.getContext("webgl", { antialias: true }) || canvas.getContext("experimental-webgl", { antialias: true });
 
         info.WEBGL = !!gl;
 


### PR DESCRIPTION
Fixes a bug that caused scenejs to crash on browsers that don't support context "webgl" (i.e. Edge and IE).