### PR TITLE
fix examples font

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -13,7 +13,7 @@
     <style>
 
         @font-face {
-            font-family: Arial, helvetica, freesans, sans-serif monospace;
+            font-family: Arial, helvetica, freesans, sans-serif;
             font-weight: normal;
             font-style: normal;
         }
@@ -22,7 +22,7 @@
             background-color: #e8e8e8;
             margin: 0px;
             font-size: 14px;
-            font-family: Arial, helvetica, freesans, sans-serif monospace;
+            font-family: Arial, helvetica, freesans, sans-serif;
             overflow: hidden;
         }
 


### PR DESCRIPTION
Removed monospace since specifying both generic family fonts like that isn't supported.