### PR TITLE
support vertex color transparency

### DIFF
--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -804,6 +804,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
 
         if (states.geometry.colorBuf) {
             add("  vec3    color   = SCENEJS_vColor.rgb;");
+            add("  float   colorA  = SCENEJS_vColor.a;");
         } else {
             add("  vec3    color   = SCENEJS_uMaterialColor;")
         }
@@ -1174,6 +1175,10 @@ var SceneJS_ProgramSourceFactory = new (function () {
                             " * specular * pow(max(dot(reflect(normalize(-viewLightVec), normalize(-viewNormalVec)), normalize(-SCENEJS_vViewVertex.xyz)), 0.0), shine);");
                     }
                 }
+            }
+
+            if (states.geometry.colorBuf) {
+                add("alpha *= colorA;");
             }
 
             if (diffuseFresnel || specularFresnel || alphaFresnel || emitFresnel) {


### PR DESCRIPTION
Fix for #348 : incorporate vertex color's alpha component in fragment shader.  Please let me know if I missed anything!

Example of top vertices with lowered alphas on the geometry/vertexColors example:
![vertexcoloralpha](https://cloud.githubusercontent.com/assets/2723678/13278309/7c80a1ac-da84-11e5-8983-2f9d35c6fe8d.png)
