### PR TITLE
Alpha pre-multiplied in fragment shader for proper compositing.

### DIFF
--- a/src/core/display/chunks/flagsChunk.js
+++ b/src/core/display/chunks/flagsChunk.js
@@ -63,7 +63,7 @@ SceneJS_ChunkFactory.createChunkType({
                     // Entering a transparency bin
 
                     gl.enable(gl.BLEND);
-                    gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+                    gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
                     frameCtx.blendEnabled = true;
 
                 } else {

--- a/src/core/display/chunks/regionMapChunk.js
+++ b/src/core/display/chunks/regionMapChunk.js
@@ -30,7 +30,7 @@ SceneJS_ChunkFactory.createChunkType({
                 // Entering a transparency bin
 
                 gl.enable(gl.BLEND);
-                gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+                gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
                 frameCtx.blendEnabled = true;
 
             } else {

--- a/src/core/display/chunks/renderTargetChunk.js
+++ b/src/core/display/chunks/renderTargetChunk.js
@@ -36,7 +36,7 @@ SceneJS_ChunkFactory.createChunkType({
             //  Enable blending for non-depth targets
             if (frameCtx.blendEnabled) {
                 gl.enable(gl.BLEND);
-                gl.blendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+                gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
             }
         }
 

--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -1304,6 +1304,10 @@ var SceneJS_ProgramSourceFactory = new (function () {
             add("fragColor.rgb *= mix(SCENEJS_uFragmentFresnelEdgeColor.rgb, SCENEJS_uFragmentFresnelCenterColor.rgb, fragmentFresnel);");
         }
 
+        if (!depthTargeting) {
+            add("fragColor.rgb *= fragColor.a;");
+        }
+
         add("gl_FragColor = fragColor;");
 
         add("}");


### PR DESCRIPTION
Update to ensure proper compositing with a transparent canvas. The browser assumes that alphas are pre-multiplied when compositing a transparent canvas with the reset of the page. This causes transparent objects to appear overly saturated. This update multiplies output colors from the fragment shader by the final alpha. For this to work properly, the blend function also had to be changed to (gl.ONE, gl.ONE_MINUS_SRC_ALPHA).

(Discussion of the issue can be found [here](http://webglfundamentals.org/webgl/lessons/webgl-and-alpha.html)).

As an example of the difference, here's the alpha texture example without pre-multiplication:
![notpremultiplied](https://cloud.githubusercontent.com/assets/476017/13797020/a55cce86-eae0-11e5-9dcf-d70f17b9a44a.png)

And with pre-multiplication:
![premultiplied](https://cloud.githubusercontent.com/assets/476017/13797022/b1cfff94-eae0-11e5-8542-6998c59e4506.png)

@xeolabs, can you take a look at this? It seems to work with all the examples, but I want to make sure I'm not missing anything, as this is a fairly significant update.