### PR TITLE
Optimize picking primitive generation

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -579,6 +579,7 @@
             "picking_rayPicking",
             "picking_rayPicking_onTransparentObject",
             "picking_rayPicking_triangles",
+            "picking_rayPicking_trianglePerformance",
             "picking_rayPicking_morphTargets",
             "picking_rayPicking_performance",
             "picking_regions_info",

--- a/examples/picking_rayPicking_trianglePerformance.html
+++ b/examples/picking_rayPicking_trianglePerformance.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>SceneJS Example - Ray Picking Performance</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+
+    <script src="../api/latest/scenejs.js"></script>
+    <link href="css/styles.css" rel="stylesheet"/>
+
+    <style>
+        body {
+            margin: 0;
+            -moz-user-select: -moz-none;
+            -khtml-user-select: none;
+            -webkit-user-select: none;
+        }
+
+        #info {
+            position: absolute;
+            top: 200px;
+            width: 100%;
+            color: #ffffff;
+            padding: 5px;
+            font-family: Monospace;
+            font-size: 18px;
+            text-align: center;
+            background: black;
+            opacity: 0.6;
+            z-index: 100000;
+        }
+
+        #infoTxt {
+            font-weight: bold;
+        }
+
+        #map {
+            position: absolute;
+            top: 200px;
+            left: 40px;
+            height: 256px;
+            width: 256px;
+        }
+
+        #map img {
+            width: 100%;
+        }
+
+        #map canvas {
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+    </style>
+</head>
+
+<body>
+
+<div id="infoDark">
+    <a href="http://scenejs.org" target="_other">SceneJS</a> - Triangle picking performance
+    <br>
+    This torus contains <span id="polycount"></span> triangles.
+    <br>
+    
+
+    <div id="infoTxt"></div>
+    <div id="map">
+        <img src="textures/uvGrid.jpg">
+        <canvas id="marker-canvas" width="256" height="256"></canvas>
+    </div>
+</div>
+
+<script>
+
+
+    // Point SceneJS to the bundled plugins
+    SceneJS.setConfigs({
+        pluginPath: "../api/latest/plugins"
+    });
+
+    // Define scene
+    var scene = SceneJS.createScene({
+        nodes: [
+            // Mouse-orbited camera, implemented by plugin at
+            // http://scenejs.org/api/latest/plugins/node/cameras/orbit.js
+            {
+                type: "cameras/orbit",
+                yaw: 30,
+                pitch: -40,
+                zoom: 5,
+                zoomSensitivity: 0.1,
+
+                nodes: [
+
+                    // Pickable heightmap
+                    {
+                        type: "name",
+                        name: "myHeightmap",
+
+                        nodes: [
+                            {
+                                type: "texture",
+                                src: "textures/uvGrid.jpg",
+                                applyTo: "baseColor",
+
+                                nodes: [
+
+                                    // Sphere primitive, implemented by plugin at
+                                    // http://scenejs.org/api/latest/plugins/node/geometry/sphere.js
+                                    // Torus primitive, implemented by plugin at http://scenejs.org/api/latest/plugins/node/geometry/torus.js
+                                    {
+                                        id: "torus",
+                                        type: "geometry/torus",
+                                        radius: 1.0,
+                                        tube: 0.5,
+                                        segmentsR: 800,
+                                        segmentsT: 800,
+                                        arc: Math.PI * 2
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+
+                    // Red sphere to indicate last picked position
+             
+                    {
+                        type: "flags",
+                        id: "indicatorFlags",
+                        flags: {
+                            picking: false,
+                            enabled: false
+                        },
+                        nodes: [
+
+                            {
+                                type: "material",
+                                color: {r: 1, g: 0.3, b: 0.3},
+
+                                nodes: [
+                                    {
+                                        type: "translate",
+                                        id: "worldPosIndicator",
+                                        x: 0,
+                                        y: 0,
+                                        z: 0,
+
+                                        nodes: [
+                           
+                                            // Sphere primitive implemented by plugin at
+                                            // http://scenejs.org/api/latest/plugins/node/geometry/sphere.js
+                                            {
+                                                type: "geometry/sphere",
+                                                radius: 0.05
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    });
+
+    var pickInfo = document.getElementById("infoTxt");
+    var canvas = scene.getCanvas();
+    var markerCanvas = document.getElementById("marker-canvas");
+    var markerContext = markerCanvas.getContext("2d");
+    var pickX = 0;
+    var pickY = 0;
+    markerContext.fillStyle = "red";
+
+    // Mouse event handling to do a pick on hover
+
+    canvas.addEventListener('mousemove',
+            function (event) {
+                pickX = event.clientX;
+                pickY = event.clientY;
+            }, false);
+
+    canvas.addEventListener('touchstart',
+            function touchStart(event) {
+                pickX = event.clientX;
+                pickY = event.clientY;
+            }, false);
+
+    scene.getNode("worldPosIndicator", function (worldPosIndicator) {
+        scene.getNode("indicatorFlags", function (indicatorFlags) {
+
+            scene.on("tick", function() {
+                var hit = scene.pick(pickX, pickY, {rayPick: true});
+
+                markerContext.clearRect(0, 0, markerCanvas.width, markerCanvas.height);
+                pickInfo.innerHTML = "";
+                indicatorFlags.setEnabled(false);
+
+                if (hit) {
+                    var uv = hit.uv;
+                    var normal = hit.normal;
+                    var worldPos = hit.worldPos;
+                    var barycentric = hit.barycentric;
+                    var primitiveIndex = hit.primitiveIndex;
+
+                    pickInfo.innerHTML = "UV: " + uv[0].toPrecision(2) + ", " + uv[1].toPrecision(2);
+                    pickInfo.innerHTML += " -- Normal: " + normal[0].toPrecision(2) + ", " + normal[1].toPrecision(2);
+                    pickInfo.innerHTML += "<BR>World pos: " + worldPos[0].toPrecision(2) + ", " + worldPos[1].toPrecision(2) + ", " + worldPos[2].toPrecision(2);
+                    pickInfo.innerHTML += " -- Barycentric: " + barycentric[0].toPrecision(2) + ", " + barycentric[1].toPrecision(2) + ", " + barycentric[2].toPrecision(2);
+                    pickInfo.innerHTML += "<BR>Primitive Index: " + primitiveIndex;
+
+                    markerContext.beginPath();
+                    markerContext.arc(uv[0] * markerCanvas.width, (1 - uv[1]) * markerCanvas.height, 4, 0, 2 * Math.PI);
+                    markerContext.fill();
+
+                    indicatorFlags.setEnabled(true);
+                    worldPosIndicator.setXYZ({
+                        x: worldPos[0],
+                        y: worldPos[1],
+                        z: worldPos[2]
+                    });
+                }
+
+            });
+
+        });
+    });
+
+    scene.getNode("torus", function(torus) {
+        document.getElementById("polycount").innerText = torus.nodes[0]._core.arrays.indices.length / 3;
+    })
+
+
+</script>
+</body>
+</html>

--- a/src/core/display/chunks/drawChunk.js
+++ b/src/core/display/chunks/drawChunk.js
@@ -62,10 +62,10 @@ SceneJS_ChunkFactory.createChunkType({
 
         } else if (frameCtx.pickTriangle) {
 
-            var pickIndices = core.getPickIndices();
+            var pickPositions = core.getPickPositions();
 
-            if (pickIndices) {
-                gl.drawElements(core.primitive, pickIndices.numItems, pickIndices.itemType, 0);
+            if (pickPositions) {
+                gl.drawArrays(core.primitive, 0, pickPositions.numItems / 3);
             }
         }
     }

--- a/src/core/display/chunks/geometryChunk.js
+++ b/src/core/display/chunks/geometryChunk.js
@@ -257,11 +257,6 @@ SceneJS_ChunkFactory.createChunkType({
                     this._aColorPick.bindFloatArrayBuffer(core2.getPickColors());
                 }
 
-                var pickIndicesBuf = core2.getPickIndices();
-                if (pickIndicesBuf) {
-                    pickIndicesBuf.bind()
-                }
-
             } else if (this._aVertexPick) {
 
                 this._aVertexPick.bindFloatArrayBuffer(core2.vertexBuf);
@@ -306,12 +301,6 @@ SceneJS_ChunkFactory.createChunkType({
 
                 if (this._aColorPick) {
                     this._aColorPick.bindFloatArrayBuffer(core2.getPickColors());
-                }
-
-                var pickIndices = core2.getPickIndices();
-
-                if (pickIndices) {
-                    pickIndices.bind()
                 }
 
             }

--- a/src/core/math.js
+++ b/src/core/math.js
@@ -2169,12 +2169,20 @@
 
         pickTris = pickTris || {};
 
-        var pickPositions = [];
-        var pickColors = [];
-        var pickIndices = [];
+        var numIndices = indices.length;
+
+        var pickPositions = new Float32Array(numIndices * 3);
+        var pickColors = new Float32Array(numIndices * 4);
+        var pickIndices = new indices.constructor(numIndices);
 
         var index2 = 0;
         var primIndex = 0;
+
+        // Vertex index
+        var vi;
+
+        // Color index
+        var ci;
 
         // Triangle indices
 
@@ -2184,7 +2192,10 @@
         var b;
         var a;
 
-        for (var location = 0; location < indices.length; location += 3) {
+        for (var location = 0; location < numIndices; location += 3) {
+
+            vi = location * 3;
+            ci = location * 4;
 
             // Primitive-indexed triangle pick color
 
@@ -2207,48 +2218,48 @@
 
             // A
 
-            i = indices[location + 0];
+            i = indices[location];
 
-            pickPositions.push(positions[i * 3 + 0]);
-            pickPositions.push(positions[i * 3 + 1]);
-            pickPositions.push(positions[i * 3 + 2]);
+            pickPositions[vi]     = positions[i * 3];
+            pickPositions[vi + 1] = positions[i * 3 + 1];
+            pickPositions[vi + 2] = positions[i * 3 + 2];
 
-            pickColors.push(r);
-            pickColors.push(g);
-            pickColors.push(b);
-            pickColors.push(a);
+            pickColors[ci]     = r;
+            pickColors[ci + 1] = g;
+            pickColors[ci + 2] = b;
+            pickColors[ci + 3] = a;
 
-            pickIndices.push(index2++);
+            pickIndices[index2] = index2++;
 
             // B
 
             i = indices[location + 1];
 
-            pickPositions.push(positions[i * 3 + 0]);
-            pickPositions.push(positions[i * 3 + 1]);
-            pickPositions.push(positions[i * 3 + 2]);
+            pickPositions[vi + 3] = positions[i * 3];
+            pickPositions[vi + 4] = positions[i * 3 + 1];
+            pickPositions[vi + 5] = positions[i * 3 + 2];
 
-            pickColors.push(r);
-            pickColors.push(g);
-            pickColors.push(b);
-            pickColors.push(a);
+            pickColors[ci + 4] = r;
+            pickColors[ci + 5] = g;
+            pickColors[ci + 6] = b;
+            pickColors[ci + 7] = a;
 
-            pickIndices.push(index2++);
+            pickIndices[index2] = index2++;
 
             // C
 
             i = indices[location + 2];
 
-            pickPositions.push(positions[i * 3 + 0]);
-            pickPositions.push(positions[i * 3 + 1]);
-            pickPositions.push(positions[i * 3 + 2]);
+            pickPositions[vi + 6] = positions[i * 3];
+            pickPositions[vi + 7] = positions[i * 3 + 1];
+            pickPositions[vi + 8] = positions[i * 3 + 2];
 
-            pickColors.push(r);
-            pickColors.push(g);
-            pickColors.push(b);
-            pickColors.push(a);
+            pickColors[ci + 8]  = r;
+            pickColors[ci + 9]  = g;
+            pickColors[ci + 10] = b;
+            pickColors[ci + 11] = a;
 
-            pickIndices.push(index2++);
+            pickIndices[index2] = index2++;
         }
 
         pickTris.pickPositions = pickPositions;
@@ -2268,13 +2279,12 @@
      */
     window.SceneJS_math_getPickIndices = function (indices) {
 
-        var pickIndices = [];
+        var numIndices = indices.length;
 
-        var index2 = 0;
-        for (var location = 0; location < indices.length; location += 3) {
-            pickIndices.push(index2++);
-            pickIndices.push(index2++);
-            pickIndices.push(index2++);
+        var pickIndices = new indices.constructor(numIndices);
+
+        for (var i = 0; i < numIndices; i++) {
+            pickIndices[i] = i;
         }
 
         return pickIndices;
@@ -2291,40 +2301,26 @@
      */
     window.SceneJS_math_getPickPositions = function (positions, indices) {
 
-        var pickPositions = [];
-        var primIndex = 0;
+        var numIndices = indices.length;
+
+        var pickPositions = new Float32Array(numIndices * 3);
+        var pvi, vi;
         var i;
 
-        for (var location = 0; location < indices.length; location += 3) {
+        for (var location = 0; location < numIndices; location++) {
 
-            // Primitive-indexed triangle pick color
+            // Picking position array index
+            pvi = location * 3;
 
-            primIndex++;
-            primIndex = location + 1;
+            i = indices[location];
 
-            // A
+            // Drawing position index
+            vi = i * 3;
 
-            i = indices[location + 0];
+            pickPositions[pvi]     = positions[vi];
+            pickPositions[pvi + 1] = positions[vi + 1];
+            pickPositions[pvi + 2] = positions[vi + 2];
 
-            pickPositions.push(positions[i * 3 + 0]);
-            pickPositions.push(positions[i * 3 + 1]);
-            pickPositions.push(positions[i * 3 + 2]);
-
-            // B
-
-            i = indices[location + 1];
-
-            pickPositions.push(positions[i * 3 + 0]);
-            pickPositions.push(positions[i * 3 + 1]);
-            pickPositions.push(positions[i * 3 + 2]);
-
-            // C
-
-            i = indices[location + 2];
-
-            pickPositions.push(positions[i * 3 + 0]);
-            pickPositions.push(positions[i * 3 + 1]);
-            pickPositions.push(positions[i * 3 + 2]);
         }
 
         return pickPositions;
@@ -2340,10 +2336,12 @@
      */
     window.SceneJS_math_getPickColors = function (indices) {
 
-        var pickColors = [];
+        var numIndices = indices.length;
 
-        var index2 = 0;
+        var pickColors = new Float32Array(numIndices * 4);
+
         var primIndex = 0;
+        var pci;
 
         // Triangle indices
 
@@ -2352,11 +2350,10 @@
         var b;
         var a;
 
-        //if ((indices.length/3) > 4294967295) {
-        //    alert("!");
-        //}
+        for (var location = 0; location < numIndices; location += 3) {
 
-        for (var location = 0; location < indices.length; location += 3) {
+            // Picking color array index;
+            pci = location * 4;
 
             // Primitive-indexed triangle pick color
 
@@ -2367,24 +2364,24 @@
 
             // A
 
-            pickColors.push(r);
-            pickColors.push(g);
-            pickColors.push(b);
-            pickColors.push(a);
+            pickColors[pci]     = r;
+            pickColors[pci + 1] = g;
+            pickColors[pci + 2] = b;
+            pickColors[pci + 3] = a;
 
             // B
 
-            pickColors.push(r);
-            pickColors.push(g);
-            pickColors.push(b);
-            pickColors.push(a);
+            pickColors[pci + 4] = r;
+            pickColors[pci + 5] = g;
+            pickColors[pci + 6] = b;
+            pickColors[pci + 7] = a;
 
             // C
 
-            pickColors.push(r);
-            pickColors.push(g);
-            pickColors.push(b);
-            pickColors.push(a);
+            pickColors[pci + 8]  = r;
+            pickColors[pci + 9]  = g;
+            pickColors[pci + 10] = b;
+            pickColors[pci + 11] = a;
 
             primIndex++;
         }

--- a/src/core/math.js
+++ b/src/core/math.js
@@ -2161,28 +2161,25 @@
      * @static
      * @param {Array of Number} positions One-dimensional flattened array of positions.
      * @param {Array of Number} indices One-dimensional flattened array of indices.
-     * @param {*} [pickTris] Optional object to return the arrays on.
-     * @param {Boolean} [debug] Assigns random colors to triangles when true.
      * @returns {*} Object containing the arrays, created by this method or reused from 'pickTris' parameter.
      */
-    window.SceneJS_math_getPickPrimitives = function (positions, indices, pickTris, debug) {
-
-        pickTris = pickTris || {};
+    window.SceneJS_math_getPickPrimitives = function (positions, indices) {
 
         var numIndices = indices.length;
 
         var pickPositions = new Float32Array(numIndices * 3);
         var pickColors = new Float32Array(numIndices * 4);
-        var pickIndices = new indices.constructor(numIndices);
 
-        var index2 = 0;
         var primIndex = 0;
 
-        // Vertex index
+        // Positions array index
         var vi;
 
-        // Color index
-        var ci;
+        // Picking positions array index
+        var pvi;
+
+        // Picking color array index
+        var pci;
 
         // Triangle indices
 
@@ -2194,100 +2191,67 @@
 
         for (var location = 0; location < numIndices; location += 3) {
 
-            vi = location * 3;
-            ci = location * 4;
+            pvi = location * 3;
+            pci = location * 4;
 
             // Primitive-indexed triangle pick color
 
-            primIndex++;
-            primIndex = location + 1;
-
-
-            if (debug) {
-                r = Math.random();
-                g = Math.random();
-                b = Math.random();
-                a = 1.0;
-            } else {
-                b = (primIndex >> 16 & 0xFF) / 255;
-                g = (primIndex >> 8 & 0xFF) / 255;
-                r = (primIndex & 0xFF) / 255;
-                a = 1.0;
-            }
-
+            a = (primIndex >> 24 & 0xFF) / 255.0;
+            b = (primIndex >> 16 & 0xFF) / 255.0;
+            g = (primIndex >> 8 & 0xFF) / 255.0;
+            r = (primIndex & 0xFF) / 255.0;
 
             // A
 
             i = indices[location];
+            vi = i * 3;
 
-            pickPositions[vi]     = positions[i * 3];
-            pickPositions[vi + 1] = positions[i * 3 + 1];
-            pickPositions[vi + 2] = positions[i * 3 + 2];
+            pickPositions[pvi]     = positions[vi];
+            pickPositions[pvi + 1] = positions[vi + 1];
+            pickPositions[pvi + 2] = positions[vi + 2];
 
-            pickColors[ci]     = r;
-            pickColors[ci + 1] = g;
-            pickColors[ci + 2] = b;
-            pickColors[ci + 3] = a;
+            pickColors[pci]     = r;
+            pickColors[pci + 1] = g;
+            pickColors[pci + 2] = b;
+            pickColors[pci + 3] = a;
 
-            pickIndices[index2] = index2++;
 
             // B
 
             i = indices[location + 1];
+            vi = i * 3;
 
-            pickPositions[vi + 3] = positions[i * 3];
-            pickPositions[vi + 4] = positions[i * 3 + 1];
-            pickPositions[vi + 5] = positions[i * 3 + 2];
+            pickPositions[pvi + 3] = positions[vi];
+            pickPositions[pvi + 4] = positions[vi + 1];
+            pickPositions[pvi + 5] = positions[vi + 2];
 
-            pickColors[ci + 4] = r;
-            pickColors[ci + 5] = g;
-            pickColors[ci + 6] = b;
-            pickColors[ci + 7] = a;
+            pickColors[pci + 4] = r;
+            pickColors[pci + 5] = g;
+            pickColors[pci + 6] = b;
+            pickColors[pci + 7] = a;
 
-            pickIndices[index2] = index2++;
 
             // C
 
             i = indices[location + 2];
+            vi = i * 3;
 
-            pickPositions[vi + 6] = positions[i * 3];
-            pickPositions[vi + 7] = positions[i * 3 + 1];
-            pickPositions[vi + 8] = positions[i * 3 + 2];
+            pickPositions[pvi + 6] = positions[vi];
+            pickPositions[pvi + 7] = positions[vi + 1];
+            pickPositions[pvi + 8] = positions[vi + 2];
 
-            pickColors[ci + 8]  = r;
-            pickColors[ci + 9]  = g;
-            pickColors[ci + 10] = b;
-            pickColors[ci + 11] = a;
+            pickColors[pci + 8]  = r;
+            pickColors[pci + 9]  = g;
+            pickColors[pci + 10] = b;
+            pickColors[pci + 11] = a;
 
-            pickIndices[index2] = index2++;
+            primIndex++;
         }
 
-        pickTris.pickPositions = pickPositions;
-        pickTris.pickColors = pickColors;
-        pickTris.pickIndices = pickIndices;
-
-        return pickTris;
-    };
-
-    /**
-     * Builds index array needed by color-indexed triangle picking (for morph target positions).
-     *
-     * @method getPickIndices
-     * @static
-     * @param {Array of Number} indices One-dimensional flattened array of indices.
-     * @returns {Array of Number} The pick indices.
-     */
-    window.SceneJS_math_getPickIndices = function (indices) {
-
-        var numIndices = indices.length;
-
-        var pickIndices = new indices.constructor(numIndices);
-
-        for (var i = 0; i < numIndices; i++) {
-            pickIndices[i] = i;
-        }
-
-        return pickIndices;
+        return {
+            positions: pickPositions,
+            colors: pickColors
+        };
     };
 
     /**

--- a/src/core/scene/geometry.js
+++ b/src/core/scene/geometry.js
@@ -212,7 +212,7 @@ new (function () {
             if (core.arrays.positions) {
                 var gl = self._engine.canvas.gl;
                 var pickPositions = SceneJS_math_getPickPositions(core.arrays.positions, core.arrays.indices);
-                core.pickPositionsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, new Float32Array(pickPositions), pickPositions.length, 3, gl.STATIC_DRAW);
+                core.pickPositionsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickPositions, pickPositions.length, 3, gl.STATIC_DRAW);
             }
 
             return core.pickPositionsBuf;
@@ -224,20 +224,8 @@ new (function () {
             }
             var gl = self._engine.canvas.gl;
             var pickColors = SceneJS_math_getPickColors(core.arrays.indices);
-            core.pickColorsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, new Float32Array(pickColors), pickColors.length, 4, gl.STATIC_DRAW);
+            core.pickColorsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickColors, pickColors.length, 4, gl.STATIC_DRAW);
             return core.pickColorsBuf;
-        };
-
-        core.getPickIndices = function () {
-            if (core.pickIndicesBuf) {
-                return core.pickIndicesBuf;
-            }
-            if (core.arrays.indices) {
-                var gl = self._engine.canvas.gl;
-                var pickIndices = SceneJS_math_getPickIndices(core.arrays.indices);
-                core.pickIndicesBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ELEMENT_ARRAY_BUFFER, new Uint16Array(pickIndices), pickIndices.length, 1, gl.STATIC_DRAW);
-            }
-            return core.pickIndicesBuf;
         };
     };
 

--- a/src/core/scene/geometry.js
+++ b/src/core/scene/geometry.js
@@ -209,11 +209,8 @@ new (function () {
             if (core.pickPositionsBuf) {
                 return core.pickPositionsBuf;
             }
-            if (core.arrays.positions) {
-                var gl = self._engine.canvas.gl;
-                var pickPositions = SceneJS_math_getPickPositions(core.arrays.positions, core.arrays.indices);
-                core.pickPositionsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickPositions, pickPositions.length, 3, gl.STATIC_DRAW);
-            }
+            
+            createPickArrays();
 
             return core.pickPositionsBuf;
         };
@@ -222,11 +219,28 @@ new (function () {
             if (core.pickColorsBuf) {
                 return core.pickColorsBuf;
             }
-            var gl = self._engine.canvas.gl;
-            var pickColors = SceneJS_math_getPickColors(core.arrays.indices);
-            core.pickColorsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickColors, pickColors.length, 4, gl.STATIC_DRAW);
+            
+            createPickArrays();
+
             return core.pickColorsBuf;
         };
+
+        function createPickArrays() {
+            var gl = self._engine.canvas.gl;
+
+            var pickArrays, pickPositions, pickColors;
+
+            if (core.arrays.positions) {
+                pickArrays = SceneJS_math_getPickPrimitives(core.arrays.positions, core.arrays.indices);
+                pickPositions = pickArrays.positions;
+                pickColors = pickArrays.colors;
+                core.pickPositionsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickPositions, pickPositions.length, 3, gl.STATIC_DRAW);
+            } else {
+                pickColors = SceneJS_math_getPickColors(core.arrays.indices);
+            }
+
+            core.pickColorsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickColors, pickColors.length, 4, gl.STATIC_DRAW);
+        } 
     };
 
 

--- a/src/core/scene/morphGeometry.js
+++ b/src/core/scene/morphGeometry.js
@@ -226,7 +226,7 @@ new (function () {
 
                 pickPositions = SceneJS_math_getPickPositions(target.positions, indices);
 
-                target.pickPositionsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, new Float32Array(pickPositions), pickPositions.length, 3, usage);
+                target.pickPositionsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickPositions, pickPositions.length, 3, usage);
             }
         }
 


### PR DESCRIPTION
Significant optimizations to the the generation of picking primitives for ray picking. In the new performance example provided, time to generate picking primitives was reduced from ~380ms to ~60ms. Memory churn is also reduced due to picking geometry arrays being pre-allocated, and overall memory footprint is reduced because picking primitives no longer need an index array.

Also fixes a bug that prevented picking from working with meshes containing more than 64k vertices.

Key changes include:
- Use `drawArrays` to draw picking primitives, so indices are no longer needed.
- Pre-allocate arrays for picking positions and colors rather than pushing to dynamic arrays.
- Don't re-allocate arrays when creating WebGL buffers.
- Get picking positions and colors in a single pass, if possible.
-  Example of ray picking on an extremely large mesh (1.28M triangles).