### PR TITLE
Prevent uniform cache from referencing outside array

### DIFF
--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -1075,9 +1075,9 @@ var SceneJS_ProgramSourceFactory = new (function () {
                     add("lightDist = length( SCENEJS_uLightPos" + i + " - SCENEJS_vWorldVertex.xyz);");
 
                     add("attenuation = 1.0 - (" +
-                        "  SCENEJS_uLightAttenuation" + i + "[0] + " +
-                        "  SCENEJS_uLightAttenuation" + i + "[1] * lightDist + " +
-                        "  SCENEJS_uLightAttenuation" + i + "[2] * lightDist * lightDist);");
+                        "  SCENEJS_uLightAttenuation" + i + ".x + " +
+                        "  SCENEJS_uLightAttenuation" + i + ".y * lightDist + " +
+                        "  SCENEJS_uLightAttenuation" + i + ".z * lightDist * lightDist);");
 
                     if (light.diffuse) {
                         add("      lightValue += dotN * SCENEJS_uLightColor" + i + " * attenuation;");
@@ -1130,9 +1130,9 @@ var SceneJS_ProgramSourceFactory = new (function () {
                     add("lightDist = length( SCENEJS_uLightPos" + i + " - SCENEJS_vWorldVertex.xyz);");
 
                     add("attenuation = 1.0 - (" +
-                        "  SCENEJS_uLightAttenuation" + i + "[0] + " +
-                        "  SCENEJS_uLightAttenuation" + i + "[1] * lightDist + " +
-                        "  SCENEJS_uLightAttenuation" + i + "[2] * lightDist * lightDist);");
+                        "  SCENEJS_uLightAttenuation" + i + ".x + " +
+                        "  SCENEJS_uLightAttenuation" + i + ".y * lightDist + " +
+                        "  SCENEJS_uLightAttenuation" + i + ".z * lightDist * lightDist);");
 
                     add("coneDiff = SCENEJS_uOuterCone" + i + " - SCENEJS_uInnerCone" + i + ";");
 

--- a/src/core/webgl/uniform.js
+++ b/src/core/webgl/uniform.js
@@ -15,32 +15,41 @@ SceneJS._webgl.Uniform = function (gl, program, name, type, size, location, inde
         };
 
     } else if (type === gl.BOOL_VEC2) {
+        value = new Array(2);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1]) {
                 return;
             }
-            value = v;
+            value[0] = v[0];
+            value[1] = v[1];
             gl.uniform2iv(location, v);
         };
 
     } else if (type === gl.BOOL_VEC3) {
+        value = new Array(3);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1] && value[2] === v[2]) {
                 return;
             }
-            value = v;
+            value[0] = v[0];
+            value[1] = v[1];
+            value[2] = v[2];
             gl.uniform3iv(location, v);
         };
 
     } else if (type === gl.BOOL_VEC4) {
+        value = new Array(4);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1] && value[2] === v[2] && value[3] === v[3]) {
                 return;
             }
-            value = v;
+            value[0] = v[0];
+            value[1] = v[1];
+            value[2] = v[2];
+            value[3] = v[3];
             gl.uniform4iv(location, v);
         };
 
@@ -55,32 +64,35 @@ SceneJS._webgl.Uniform = function (gl, program, name, type, size, location, inde
         };
 
     } else if (type === gl.INT_VEC2) {
+        value = new Uint32Array(2);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1]) {
                 return;
             }
-            value = v;
+            value.set(v);
             gl.uniform2iv(location, v);
         };
 
     } else if (type === gl.INT_VEC3) {
+        value = new Uint32Array(3);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1] && value[2] === v[2]) {
                 return;
             }
-            value = v;
+            value.set(v);
             gl.uniform3iv(location, v);
         };
 
     } else if (type === gl.INT_VEC4) {
+        value = new Uint32Array(4);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1] && value[2] === v[2] && value[3] === v[3]) {
                 return;
             }
-            value = v;
+            value.set(v);
             gl.uniform4iv(location, v);
         };
 
@@ -95,32 +107,35 @@ SceneJS._webgl.Uniform = function (gl, program, name, type, size, location, inde
         };
 
     } else if (type === gl.FLOAT_VEC2) {
+        value = new Float32Array(2);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1]) {
                 return;
             }
-            value = v;
+            value.set(v);
             gl.uniform2fv(location, v);
         };
 
     } else if (type === gl.FLOAT_VEC3) {
+        value = new Float32Array(3);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1] && value[2] === v[2]) {
                 return;
             }
-            value = v;
+            value.set(v);
             gl.uniform3fv(location, v);
         };
 
     } else if (type === gl.FLOAT_VEC4) {
+        value = new Float32Array(4);
 
         func = function (v) {
             if (value !== null && value[0] === v[0] && value[1] === v[1] && value[2] === v[2] && value[3] === v[3]) {
                 return;
             }
-            value = v;
+            value.set(v);
             gl.uniform4fv(location, v);
         };
 


### PR DESCRIPTION
This update prevents the uniform cache from storing a reference to argument arrays directly. The problem can be seen in the following example:
```JavaScript
var array = [1, 2, 3];
uniform.setValue(array);   // Uniform caches a direct reference to array!
array[0] = 5;
uniform.setValue(array);   // Uniform not updated because the new value is already in the cache!
```

The update creates a separate array to cache the value, and manually copies values over to prevent this.

I also changed the reference to `SCENEJS_uLightAttenuation` in the FS to use the more common x, y, z accessors, rather than array notation. I think it's more clear, but let me know if you think otherwise.