### PR TITLE
Array slice

### DIFF
--- a/src/core/display/display.js
+++ b/src/core/display/display.js
@@ -712,7 +712,7 @@ SceneJS_Display.prototype._buildDrawList = function () {
         tagMask = this._tagSelector.mask;
         tagRegex = this._tagSelector.regex;
     }
-    
+
     for (i = 0, len = this._objectListLen; i < len; i++) {
 
         object = this._objectList[i];
@@ -1224,7 +1224,7 @@ SceneJS_Display.prototype._logPickList = function () {
                     c[1] = positions[ic3 + 1];
                     c[2] = positions[ic3 + 2];
                 }
-                
+
 
                 // Get Local-space cartesian coordinates of the ray-triangle intersection
 
@@ -1241,12 +1241,12 @@ SceneJS_Display.prototype._logPickList = function () {
 
                 SceneJS_math_transformVector4(object.modelTransform.matrix, tempVec4, tempVec4b);
 
-                hit.worldPos = tempVec4b.slice(0, 3);
+                hit.worldPos = SceneJS._sliceArray(tempVec4b, 0, 3);
 
                 // Get barycentric coordinates of the ray-triangle intersection
 
                 var barycentric = hit.barycentric = SceneJS_math_cartesianToBarycentric2(position, a, b, c, SceneJS_math_vec3());
-                
+
                 // Get interpolated normal vector
 
                 var gotNormals = false;

--- a/src/core/scenejs.js
+++ b/src/core/scenejs.js
@@ -371,6 +371,28 @@ var SceneJS = new (function () {
     };
 
     /**
+    * Shim for slicing arrays regardless of the array type.
+    * (Primarily because TypedArray.prototype.slice is
+    * not supported on all platforms)
+    */
+    this._sliceArray = function(array, start, end) {
+        if (typeof array.slice === "function") {
+            return array.slice(start, end);
+        }
+
+        end = end || array.length;
+
+        var length = end - start;
+        var newArray = new array.constructor(length);
+
+        for (var i = 0; i < length; i++) {
+            newArray[i] = array[start + i];
+        }
+
+        return newArray;
+    };
+
+    /**
      * Resets SceneJS, destroying all existing scenes
      */
     this.reset = function () {

--- a/src/core/scenejs.js
+++ b/src/core/scenejs.js
@@ -376,7 +376,7 @@ var SceneJS = new (function () {
     * not supported on all platforms)
     */
     this._sliceArray = function(array, start, end) {
-        if (typeof array.slice === "function") {
+        if (array.slice) {
             return array.slice(start, end);
         }
 


### PR DESCRIPTION
The use of TypedArray.prototype.slice in picking broke it on Safari and IE. 

This update introduces the function `SceneJS._sliceArray` to handle slicing of any type of array. I only used for picking as that was broken, but I think it should be used more generally in the code, so we don't have to worry about what kind of array we're slicing.