### PR TITLE
Fix compilation of transform nodes

### DIFF
--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -302,6 +302,10 @@ SceneJS_Engine.prototype.branchDirty = function (node) {
     node.branchDirty = true;
     node.dirty = true;
 
+    if (node._branchDirty) {
+        node._branchDirty();
+    }
+
     for (var n = node.parent; n && !(n.dirty || n.branchDirty); n = n.parent) { // Flag path down to this node
         n.dirty = true;
     }

--- a/src/core/scene/matrix.js
+++ b/src/core/scene/matrix.js
@@ -78,6 +78,10 @@ SceneJS.Matrix.prototype.setMatrix = function(elements) {
  */
 SceneJS.Matrix.prototype.setElements = SceneJS.Matrix.prototype.setMatrix;
 
+SceneJS.Matrix.prototype._branchDirty = function() {
+    SceneJS_modelXFormStack.compileCore(this._core);
+};
+
 SceneJS.Matrix.prototype._compile = function(ctx) {
     SceneJS_modelXFormStack.push(this._core);
     this._compileNodes(ctx);

--- a/src/core/scene/rotate.js
+++ b/src/core/scene/rotate.js
@@ -9,7 +9,7 @@ SceneJS.Rotate.prototype._init = function(params) {
     if (this._core.useCount == 1) { // This node is the resource definer
 
         SceneJS_modelXFormStack.buildCore(this._core);
-        
+
         this.setMultOrder(params.multOrder);
 
         this.setAngle(params.angle);
@@ -139,6 +139,10 @@ SceneJS.Rotate.prototype.incAngle = function(angle) {
     this._core.angle += angle;
     this._core.setDirty();
     this._engine.display.imageDirty = true;
+};
+
+SceneJS.Rotate.prototype._branchDirty = function() {
+    SceneJS_modelXFormStack.compileCore(this._core);
 };
 
 SceneJS.Rotate.prototype._compile = function(ctx) {

--- a/src/core/scene/scale.js
+++ b/src/core/scene/scale.js
@@ -140,6 +140,10 @@ SceneJS.Scale.prototype.incZ = function (z) {
     this._engine.display.imageDirty = true;
 };
 
+SceneJS.Scale.prototype._branchDirty = function() {
+    SceneJS_modelXFormStack.compileCore(this._core);
+};
+
 SceneJS.Scale.prototype._compile = function (ctx) {
     SceneJS_modelXFormStack.push(this._core);
     this._compileNodes(ctx);

--- a/src/core/scene/translate.js
+++ b/src/core/scene/translate.js
@@ -9,7 +9,7 @@ SceneJS.Translate.prototype._init = function(params) {
     if (this._core.useCount == 1) { // This node is the resource definer
 
         SceneJS_modelXFormStack.buildCore(this._core);
-        
+
         this.setMultOrder(params.multOrder);
 
         this.setXYZ({
@@ -149,6 +149,10 @@ SceneJS.Translate.prototype.getY = function() {
 
 SceneJS.Translate.prototype.getZ = function() {
     return this._core.z;
+};
+
+SceneJS.Translate.prototype._branchDirty = function() {
+    SceneJS_modelXFormStack.compileCore(this._core);
 };
 
 SceneJS.Translate.prototype._compile = function(ctx) {

--- a/src/core/scene/xform.js
+++ b/src/core/scene/xform.js
@@ -73,6 +73,10 @@ SceneJS.XForm.prototype.setElements = function (elements) {
     return this;
 };
 
+SceneJS.XForm.prototype._branchDirty = function() {
+    SceneJS_modelXFormStack.compileCore(this._core);
+};
+
 SceneJS.XForm.prototype._compile = function (ctx) {
     SceneJS_modelXFormStack.push(this._core);
     this._compileNodes(ctx);


### PR DESCRIPTION
This fixes a bug that caused transform nodes to break on scenes that dynamically update the scene graph in significant ways. The key issue is that when a transform node of any sort was compiled, it would push its core onto the xform stack, which would [clear all of the core's children](https://github.com/xeolabs/scenejs/blob/master/src/core/scene/modelXFormStack.js#L199). The problem is that if any of those children were from node branches that hadn't been marked as dirty (and thus aren't set to be compiled), they would not be re-pushed onto the stack. The transforms they represented would be lost.

This solution involves a few changes to how transform nodes are handled:
- Introduce a `_branchDirty` hook on all nodes, so they can define some behaviour to occur when their branches are marked as dirty.
- When marked as dirty, transform nodes mark their cores as `compiling`. This indicates that they will be pushed onto the stack on a subsequent compilation.
- When a core is pushed onto the xform stack, only the child cores marked as `compiling` are cleared from the list of children, since they are the ones that will be pushed again later. (Note that the filtering happens in place, to avoid memory churn).

@xeolabs, let me know if you see any issues with this approach.