### PR TITLE
Improved handling of point geometry

### DIFF
--- a/examples/geometry_points.html
+++ b/examples/geometry_points.html
@@ -14,7 +14,7 @@
         }
     </style>
 
-    <script src="../api/latest/scenejs.min.js"></script>
+    <script src="../api/latest/scenejs.js"></script>
     <link href="css/styles.css" rel="stylesheet"/>
 
 <body>
@@ -31,7 +31,7 @@
     });
 
     // Create scene
-    SceneJS.createScene({
+    var scene = SceneJS.createScene({
         nodes:[
 
             // Mouse-orbited camera, implemented by plugin at
@@ -54,6 +54,7 @@
                             {
 
                                 type:"geometry",
+                                id:"points",
 
                                 // The primitive type - allowed values are
                                 // "points", "lines", "line-loop", "line-strip",
@@ -68,11 +69,7 @@
                                 // one spanning three array elements for X,Y and Z
                                 positions:createPoints(6000),
 
-                                // Indices - these organise the
-                                // positions into geometric primitives in accordance
-                                // with the "primitive" parameter,
-                                // in this case an index for each point.
-                                indices:createIndices(6000)
+                                pointSize:1
                             }
                         ]
                     }
@@ -90,15 +87,21 @@
         return p;
     }
 
-    // Helper func to create
-    function createIndices(n) {
-        n = n / 3;
-        var p = [];
-        for (var i = 0; i < n; i++) {
-            p.push(i);
-        }
-        return p;
-    }
+    scene.getNode("points", function (points) {
+        var size = points.getPointSize();
+        var increment = 0.1;
+
+        scene.on("tick", function () {
+            size += increment;
+
+            points.setPointSize(size);
+
+            if (size > 10 || size < 1) {
+                size = Math.max(1, Math.min(size, 10));
+                increment *= -1;
+            }
+        });
+    });
 
 </script>
 </body>

--- a/src/core/display/chunks/drawChunk.js
+++ b/src/core/display/chunks/drawChunk.js
@@ -31,7 +31,11 @@ SceneJS_ChunkFactory.createChunkType({
             this._depthModeDraw.setValue(frameCtx.depthMode);
         }
 
-        gl.drawElements(core.primitive, core.indexBuf.numItems, core.indexBuf.itemType, 0);
+        if (core.indexBuf) {
+            gl.drawElements(core.primitive, core.indexBuf.numItems, core.indexBuf.itemType, 0);            
+        } else {
+            gl.drawArrays(core.primitive, 0, core.vertexBuf.numItems / 3);
+        }
 
         //frameCtx.textureUnit = 0;
     },

--- a/src/core/display/chunks/geometryChunk.js
+++ b/src/core/display/chunks/geometryChunk.js
@@ -32,6 +32,7 @@ SceneJS_ChunkFactory.createChunkType({
         this._aMorphNormalDraw = draw.getAttribute("SCENEJS_aMorphNormal");
         this._aMorphTangentDraw = draw.getAttribute("SCENEJS_aMorphTangent");
         this._uMorphFactorDraw = draw.getUniform("SCENEJS_uMorphFactor");
+        this._uPointSizeDraw = draw.getUniform("SCENEJS_uPointSize");
 
         var pick = this.program.pick;
 
@@ -40,6 +41,7 @@ SceneJS_ChunkFactory.createChunkType({
         this._aColorPick = pick.getAttribute("SCENEJS_aColor");
         this._aMorphVertexPick = pick.getAttribute("SCENEJS_aMorphVertex");
         this._uMorphFactorPick = pick.getUniform("SCENEJS_uMorphFactor");
+        this._uPointSizePick = draw.getUniform("SCENEJS_uPointSize");
 
         this.VAO = null;
         this.VAOMorphKey1 = 0;
@@ -134,6 +136,10 @@ SceneJS_ChunkFactory.createChunkType({
         var doMorph = this.core.targets && this.core.targets.length;
         var cleanInterleavedBuf = this.core2.interleavedBuf && !this.core2.interleavedBuf.dirty;
 
+        if (this._uPointSizeDraw) {
+            this._uPointSizeDraw.setValue(this.core2.pointSize);
+        }
+
         if (this.VAO && frameCtx.VAO) { // Workaround for https://github.com/xeolabs/scenejs/issues/459
             frameCtx.VAO.bindVertexArrayOES(this.VAO);
             if (doMorph) {
@@ -215,7 +221,9 @@ SceneJS_ChunkFactory.createChunkType({
             }
         }
 
-        this.core2.indexBuf.bind();
+        if (this.core2.indexBuf) {
+            this.core2.indexBuf.bind();
+        }
     },
 
     morphPick: function (frameCtx) {
@@ -303,6 +311,10 @@ SceneJS_ChunkFactory.createChunkType({
                     this._aColorPick.bindFloatArrayBuffer(core2.getPickColors());
                 }
 
+            }
+
+            if (this._uPointSizePick) {
+                this._uPointSizePick.setValue(this.core2.pointSize);
             }
         }
     }

--- a/src/core/display/programSourceFactory.js
+++ b/src/core/display/programSourceFactory.js
@@ -26,6 +26,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
     var regionMapping;
     var regionInteraction;
     var depthTargeting;
+    var points;
 
     var src = ""; // Accumulates source code as it's being built
 
@@ -61,6 +62,7 @@ var SceneJS_ProgramSourceFactory = new (function () {
         regionMapping = hasRegionMap();
         regionInteraction = regionMapping && states.regionMap.mode !== "info";
         depthTargeting = hasDepthTarget();
+        points = states.geometry.primitiveName === "points";
 
         source = new SceneJS_ProgramSource(
             hash,
@@ -99,6 +101,10 @@ var SceneJS_ProgramSourceFactory = new (function () {
         add("uniform mat4 SCENEJS_uVMatrix;");
         add("uniform mat4 SCENEJS_uVNMatrix;");
         add("uniform mat4 SCENEJS_uPMatrix;");
+
+        if (points) {
+            add("uniform float SCENEJS_uPointSize;");
+        }
 
         add("varying vec4 SCENEJS_vWorldVertex;");
 
@@ -140,6 +146,10 @@ var SceneJS_ProgramSourceFactory = new (function () {
         }
 
         add("SCENEJS_vColor = SCENEJS_aColor;");
+
+        if (points) {
+            add("gl_PointSize = SCENEJS_uPointSize;");
+        }
 
         add("}");
 
@@ -300,6 +310,10 @@ var SceneJS_ProgramSourceFactory = new (function () {
         add("uniform vec3 SCENEJS_uWorldEye;");            // World-space eye position
 
         add("varying vec3 SCENEJS_vViewEyeVec;");          // View-space vector from origin to eye
+
+        if (points) {
+            add("uniform float SCENEJS_uPointSize;");
+        }
 
         if (normals) {
 
@@ -551,7 +565,9 @@ var SceneJS_ProgramSourceFactory = new (function () {
             add("SCENEJS_vRegionMapUV = SCENEJS_aRegionMapUV;");
         }
 
-        add("gl_PointSize = 3.0;");
+        if (points) {
+            add("gl_PointSize = SCENEJS_uPointSize;");
+        }
 
         add("}");
 

--- a/src/core/scene/geometry.js
+++ b/src/core/scene/geometry.js
@@ -61,6 +61,7 @@ new (function () {
 
         core.primitive = this._getPrimitiveType(primitive);
         core.primitiveName = primitive;
+        core.pointSize = data.pointSize || 1;
 
         // Generate normals
         if (data.normals) {
@@ -660,6 +661,17 @@ new (function () {
         return this.primitive;
     };
 
+    SceneJS.Geometry.prototype.getPointSize = function () {
+        return this._core.pointSize;
+    };
+
+    SceneJS.Geometry.prototype.setPointSize = function (size) {
+        if (size && this._core.pointSize !== size) {
+            this._core.pointSize = size;
+            this._engine.display.imageDirty = true;
+        }
+    };
+
     /** Returns the Model-space boundary of this geometry
      *
      * @returns {*}
@@ -743,7 +755,7 @@ new (function () {
             core = this._inheritVBOs(core);
         }
 
-        if (core.indexBuf) { // Can only render when we have indices
+        if (core.indexBuf || core.primitiveName === "points") { // Can only render when we have indices or are drawing points
 
             var parts = [                           // Safe to build geometry hash here - geometry is immutable
                 core.normalBuf ? "t" : "f",


### PR DESCRIPTION
The key thing is that this removes the requirement for indices for point geometries. This is important as there seems to be a bug in IE/Edge that causes `gl_PointSize` to be ignored when drawing indexed geometries. This is preferable anyway as indices are redundant for points. I also added the ability to set point sizes programatically and updated the points example to show this.