### PR TITLE
Fixes to non-indexed geo and matrix slicing

### DIFF
--- a/src/core/display/chunks/drawChunk.js
+++ b/src/core/display/chunks/drawChunk.js
@@ -62,7 +62,11 @@ SceneJS_ChunkFactory.createChunkType({
                 }
             }
 
-            gl.drawElements(core.primitive, core.indexBuf.numItems, core.indexBuf.itemType, 0);
+            if (core.indexBuf) {
+                gl.drawElements(core.primitive, core.indexBuf.numItems, core.indexBuf.itemType, 0);            
+            } else {
+                gl.drawArrays(core.primitive, 0, core.vertexBuf.numItems / 3);
+            }
 
         } else if (frameCtx.pickTriangle) {
 

--- a/src/core/display/chunks/geometryChunk.js
+++ b/src/core/display/chunks/geometryChunk.js
@@ -299,7 +299,9 @@ SceneJS_ChunkFactory.createChunkType({
                     this._aRegionMapUVPick.bindFloatArrayBuffer(core2.uvBufs[frameCtx.regionMapUVLayerIdx]); // Set by regionMapChunk
                 }
 
-                core2.indexBuf.bind();
+                if (core2.indexBuf) {
+                    core2.indexBuf.bind();                    
+                }
 
             } else if (frameCtx.pickTriangle) {
 

--- a/src/core/scene/camera.js
+++ b/src/core/scene/camera.js
@@ -201,7 +201,7 @@
     };
 
     SceneJS.Camera.prototype.getMatrix = function () {
-        return this._core.matrix.slice(0);
+        return SceneJS._sliceArray(this._core.matrix, 0);
     };
 
     /**

--- a/src/core/scene/lookAt.js
+++ b/src/core/scene/lookAt.js
@@ -371,7 +371,7 @@
             this._core.rebuild();
         }
 
-        return  this._core.matrix.slice(0);
+        return  SceneJS._sliceArray(this._core.matrix, 0);
     };
 
     SceneJS.Lookat.prototype.getAttributes = function () {

--- a/src/core/scene/projection.js
+++ b/src/core/scene/projection.js
@@ -165,7 +165,7 @@
     };
 
     SceneJS.Camera.prototype.getMatrix = function () {
-        return this._core.matrix.slice(0);
+        return SceneJS._sliceArray(this._core.matrix, 0);
     };
 
     /**

--- a/src/core/scenejs.js
+++ b/src/core/scenejs.js
@@ -380,6 +380,7 @@ var SceneJS = new (function () {
             return array.slice(start, end);
         }
 
+        start = start || 0;
         end = end || array.length;
 
         var length = end - start;


### PR DESCRIPTION
Couple of spots that were still assuming all geometry has indices. Also a few fixes to nodes assuming matrices use ordinary JS arrays (`slice` doesn't exist on typed arrays in Safari).