### PR TITLE
Optimizations

### DIFF
--- a/src/core/scene/geometry.js
+++ b/src/core/scene/geometry.js
@@ -210,7 +210,7 @@ new (function () {
             if (core.pickPositionsBuf) {
                 return core.pickPositionsBuf;
             }
-            
+
             createPickArrays();
 
             return core.pickPositionsBuf;
@@ -220,7 +220,7 @@ new (function () {
             if (core.pickColorsBuf) {
                 return core.pickColorsBuf;
             }
-            
+
             createPickArrays();
 
             return core.pickColorsBuf;
@@ -241,7 +241,7 @@ new (function () {
             }
 
             core.pickColorsBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, pickColors, pickColors.length, 4, gl.STATIC_DRAW);
-        } 
+        }
     };
 
 
@@ -381,100 +381,8 @@ new (function () {
      */
     SceneJS.Geometry.prototype._buildNodeCore = function (gl, core) {
 
-        var usage = gl.STATIC_DRAW; //var usage = (!arrays.fixed) ? gl.STREAM_DRAW : gl.STATIC_DRAW;
-
         try { // TODO: Modify usage flags in accordance with how often geometry is evicted
-
-            var arrays = core.arrays;
-            var canInterleave = (SceneJS.getConfigs("enableInterleaving") !== false);
-            var dataLength = 0;
-            var interleavedValues = 0;
-            var interleavedArrays = [];
-            var interleavedArrayStrides = [];
-
-            var prepareInterleaveBuffer = function (array, strideInElements) {
-                if (dataLength == 0) {
-                    dataLength = array.length / strideInElements;
-                } else if (array.length / strideInElements != dataLength) {
-                    canInterleave = false;
-                }
-                interleavedArrays.push(array);
-                interleavedArrayStrides.push(strideInElements);
-                interleavedValues += strideInElements;
-                return (interleavedValues - strideInElements) * 4;
-            };
-
-            if (arrays.positions) {
-                if (canInterleave) {
-                    core.interleavedPositionOffset = prepareInterleaveBuffer(arrays.positions, 3);
-                }
-                core.vertexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, arrays.positions, arrays.positions.length, 3, usage);
-            }
-
-            if (arrays.normals) {
-                if (canInterleave) {
-                    core.interleavedNormalOffset = prepareInterleaveBuffer(arrays.normals, 3);
-                }
-                core.normalBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, arrays.normals, arrays.normals.length, 3, usage);
-            }
-
-            if (arrays.uvs) {
-
-                var uvs = arrays.uvs;
-                var offsets;
-                var i;
-                var len;
-                var uv;
-
-                if (canInterleave) {
-                    core.interleavedUVOffsets = [];
-                    offsets = core.interleavedUVOffsets;
-                    for (i = 0, len = uvs.length; i < len; i++) {
-                        offsets.push(prepareInterleaveBuffer(arrays.uvs[i], 2));
-                    }
-                }
-
-                core.uvBufs = [];
-
-                for (i = 0, len = uvs.length; i < len; i++) {
-                    uv = arrays.uvs[i];
-                    if (uv.length > 0) {
-                        core.uvBufs.push(new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, uv, uv.length, 2, usage));
-                    }
-                }
-            }
-
-            if (arrays.colors) {
-                if (canInterleave) {
-                    core.interleavedColorOffset = prepareInterleaveBuffer(arrays.colors, 4);
-                }
-                core.colorBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, arrays.colors, arrays.colors.length, 4, usage);
-            }
-
-            if (arrays.indices) {
-                core.indexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ELEMENT_ARRAY_BUFFER, arrays.indices, arrays.indices.length, 1, usage);
-            }
-
-            if (interleavedValues > 0 && canInterleave) {
-                // We'll place the vertex attribute data interleaved in this array.
-                // This will enable us to use less bindBuffer calls and make the data
-                // efficient to address on the GPU.
-                var interleaved = [];
-
-                var arrayCount = interleavedArrays.length;
-                for (var i = 0; i < dataLength; ++i) {
-                    for (var j = 0; j < arrayCount; ++j) {
-                        var stride = interleavedArrayStrides[j];
-                        for (var k = 0; k < stride; ++k) {
-                            interleaved.push(interleavedArrays[j][i * stride + k]);
-                        }
-                    }
-                }
-                core.interleavedStride = interleavedValues * 4; // in bytes
-                core.interleavedBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, new Float32Array(interleaved), interleaved.length, interleavedValues, usage);
-                core.interleavedBuf.dirty = false;
-            }
-
+            buildCore(gl, core);
         } catch (e) { // Allocation failure - delete whatever buffers got allocated
             destroyBuffers(core);
             throw SceneJS_error.fatalError(
@@ -861,5 +769,98 @@ new (function () {
             destroyBuffers(this._core);
         }
     };
+
+    function buildCore(gl, core) {
+        var usage = gl.STATIC_DRAW;
+        var arrays = core.arrays;
+        var canInterleave = (SceneJS.getConfigs("enableInterleaving") !== false);
+        var dataLength = 0;
+        var interleavedValues = 0;
+        var interleavedArrays = [];
+        var interleavedArrayStrides = [];
+
+        var prepareInterleaveBuffer = function (array, strideInElements) {
+            if (dataLength == 0) {
+                dataLength = array.length / strideInElements;
+            } else if (array.length / strideInElements != dataLength) {
+                canInterleave = false;
+            }
+            interleavedArrays.push(array);
+            interleavedArrayStrides.push(strideInElements);
+            interleavedValues += strideInElements;
+            return (interleavedValues - strideInElements) * 4;
+        };
+
+        if (arrays.positions) {
+            if (canInterleave) {
+                core.interleavedPositionOffset = prepareInterleaveBuffer(arrays.positions, 3);
+            }
+            core.vertexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, arrays.positions, arrays.positions.length, 3, usage);
+        }
+
+        if (arrays.normals) {
+            if (canInterleave) {
+                core.interleavedNormalOffset = prepareInterleaveBuffer(arrays.normals, 3);
+            }
+            core.normalBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, arrays.normals, arrays.normals.length, 3, usage);
+        }
+
+        if (arrays.uvs) {
+
+            var uvs = arrays.uvs;
+            var offsets;
+            var i;
+            var len;
+            var uv;
+
+            if (canInterleave) {
+                core.interleavedUVOffsets = [];
+                offsets = core.interleavedUVOffsets;
+                for (i = 0, len = uvs.length; i < len; i++) {
+                    offsets.push(prepareInterleaveBuffer(arrays.uvs[i], 2));
+                }
+            }
+
+            core.uvBufs = [];
+
+            for (i = 0, len = uvs.length; i < len; i++) {
+                uv = arrays.uvs[i];
+                if (uv.length > 0) {
+                    core.uvBufs.push(new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, uv, uv.length, 2, usage));
+                }
+            }
+        }
+
+        if (arrays.colors) {
+            if (canInterleave) {
+                core.interleavedColorOffset = prepareInterleaveBuffer(arrays.colors, 4);
+            }
+            core.colorBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, arrays.colors, arrays.colors.length, 4, usage);
+        }
+
+        if (arrays.indices) {
+            core.indexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ELEMENT_ARRAY_BUFFER, arrays.indices, arrays.indices.length, 1, usage);
+        }
+
+        if (interleavedValues > 0 && canInterleave) {
+            // We'll place the vertex attribute data interleaved in this array.
+            // This will enable us to use less bindBuffer calls and make the data
+            // efficient to address on the GPU.
+            var interleaved = [];
+
+            var arrayCount = interleavedArrays.length;
+            for (var i = 0; i < dataLength; ++i) {
+                for (var j = 0; j < arrayCount; ++j) {
+                    var stride = interleavedArrayStrides[j];
+                    for (var k = 0; k < stride; ++k) {
+                        interleaved.push(interleavedArrays[j][i * stride + k]);
+                    }
+                }
+            }
+            core.interleavedStride = interleavedValues * 4; // in bytes
+            core.interleavedBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, new Float32Array(interleaved), interleaved.length, interleavedValues, usage);
+            core.interleavedBuf.dirty = false;
+        }
+    }
 
 })();

--- a/src/core/scene/morphGeometry.js
+++ b/src/core/scene/morphGeometry.js
@@ -83,95 +83,8 @@ new (function () {
 
     SceneJS.MorphGeometry.prototype._buildNodeCore = function (data) {
 
-        var targetsData = data.targets || [];
-        if (targetsData.length < 2) {
-            throw SceneJS_error.fatalError(
-                SceneJS.errors.ILLEGAL_NODE_CONFIG,
-                "morphGeometry node should have at least two targets");
-        }
-
-        var keysData = data.keys || [];
-        if (keysData.length != targetsData.length) {
-            throw SceneJS_error.fatalError(
-                SceneJS.errors.ILLEGAL_NODE_CONFIG,
-                "morphGeometry node mismatch in number of keys and targets");
-        }
-
-        var core = this._core;
-        var gl = this._engine.canvas.gl;
-        var usage = gl.STATIC_DRAW; //var usage = (!arrays.fixed) ? gl.STREAM_DRAW : gl.STATIC_DRAW;
-
-        core.keys = keysData;
-        core.targets = [];
-        core.key1 = 0;
-        core.key2 = 1;
-
-        /* First target's arrays are defaults for where not given on previous and subsequent targets.
-         * When target does have array, subsequent targets without array inherit it.
-         */
-
-        var positions;
-        var normals;
-        var uv;
-        var uv2;
-
-        var targetData;
-
-        for (var i = 0, len = targetsData.length; i < len; i++) {
-            targetData = targetsData[i];
-            if (!positions && targetData.positions) {
-                positions = targetData.positions;
-            }
-            if (!normals && targetData.normals) {
-                normals = targetData.normals;
-            }
-            if (!uv && targetData.uv) {
-                uv = targetData.uv;
-            }
-            if (!uv2 && targetData.uv2) {
-                uv2 = targetData.uv2;
-            }
-        }
-
         try {
-            var target;
-            var arry;
-
-            for (var i = 0, len = targetsData.length; i < len; i++) {
-                targetData = targetsData[i];
-                target = {};
-
-                arry = targetData.positions || positions;
-                if (arry) {
-                    target.positions = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
-                    target.vertexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.positions, arry.length, 3, usage);
-                    positions = arry;
-                }
-
-                arry = targetData.normals || normals;
-                if (arry) {
-                    target.normals = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
-                    target.normalBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.normals, arry.length, 3, usage);
-                    normals = arry;
-                }
-
-                arry = targetData.uv || uv;
-                if (arry) {
-                    target.uv = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
-                    target.uvBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv, arry.length, 2, usage);
-                    uv = arry;
-                }
-
-                arry = targetData.uv2 || uv2;
-                if (arry) {
-                    target.uv2 = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
-                    target.uvBuf2 = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv2, arry.length, 2, usage);
-                    uv2 = arry;
-                }
-
-                core.targets.push(target);  // We'll iterate this to destroy targets when we recover from error
-            }
-
+            buildCore(this, data);
         } catch (e) {
 
             /* Allocation failure - deallocate target VBOs
@@ -199,7 +112,6 @@ new (function () {
                 "Failed to allocate VBO(s) for morphGeometry: " + e);
         }
 
-        this._pickPositionsDirty = true;
     };
 
     SceneJS.MorphGeometry.prototype._buildPickPositions = function (indices) {
@@ -367,5 +279,97 @@ new (function () {
             }
         }
     };
+
+    function buildCore(node, data) {
+        var targetsData = data.targets || [];
+        if (targetsData.length < 2) {
+            throw SceneJS_error.fatalError(
+                SceneJS.errors.ILLEGAL_NODE_CONFIG,
+                "morphGeometry node should have at least two targets");
+        }
+
+        var keysData = data.keys || [];
+        if (keysData.length != targetsData.length) {
+            throw SceneJS_error.fatalError(
+                SceneJS.errors.ILLEGAL_NODE_CONFIG,
+                "morphGeometry node mismatch in number of keys and targets");
+        }
+
+        var core = node._core;
+        var gl = node._engine.canvas.gl;
+        var usage = gl.STATIC_DRAW; //var usage = (!arrays.fixed) ? gl.STREAM_DRAW : gl.STATIC_DRAW;
+
+        core.keys = keysData;
+        core.targets = [];
+        core.key1 = 0;
+        core.key2 = 1;
+
+        /* First target's arrays are defaults for where not given on previous and subsequent targets.
+         * When target does have array, subsequent targets without array inherit it.
+         */
+
+        var positions;
+        var normals;
+        var uv;
+        var uv2;
+
+        var targetData;
+
+        for (var i = 0, len = targetsData.length; i < len; i++) {
+            targetData = targetsData[i];
+            if (!positions && targetData.positions) {
+                positions = targetData.positions;
+            }
+            if (!normals && targetData.normals) {
+                normals = targetData.normals;
+            }
+            if (!uv && targetData.uv) {
+                uv = targetData.uv;
+            }
+            if (!uv2 && targetData.uv2) {
+                uv2 = targetData.uv2;
+            }
+        }
+
+        var target;
+        var arry;
+
+        for (var i = 0, len = targetsData.length; i < len; i++) {
+            targetData = targetsData[i];
+            target = {};
+
+            arry = targetData.positions || positions;
+            if (arry) {
+                target.positions = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                target.vertexBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.positions, arry.length, 3, usage);
+                positions = arry;
+            }
+
+            arry = targetData.normals || normals;
+            if (arry) {
+                target.normals = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                target.normalBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.normals, arry.length, 3, usage);
+                normals = arry;
+            }
+
+            arry = targetData.uv || uv;
+            if (arry) {
+                target.uv = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                target.uvBuf = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv, arry.length, 2, usage);
+                uv = arry;
+            }
+
+            arry = targetData.uv2 || uv2;
+            if (arry) {
+                target.uv2 = (arry.constructor == Float32Array) ? arry : new Float32Array(arry);
+                target.uvBuf2 = new SceneJS._webgl.ArrayBuffer(gl, gl.ARRAY_BUFFER, target.uv2, arry.length, 2, usage);
+                uv2 = arry;
+            }
+
+            core.targets.push(target);  // We'll iterate this to destroy targets when we recover from error
+        }
+
+        node._pickPositionsDirty = true;
+    }
 
 })();

--- a/src/core/webgl/program.js
+++ b/src/core/webgl/program.js
@@ -21,8 +21,6 @@ SceneJS._webgl.Program = function (gl, vertexSources, fragmentSources) {
     this._samplers = {};
     this._attributes = {};
 
-    this.uniformValues = [];
-
     this.materialSettings = {
         specularColor: [0, 0, 0],
         specular: 0,
@@ -76,7 +74,6 @@ SceneJS._webgl.Program = function (gl, vertexSources, fragmentSources) {
                     this._samplers[u_name] = new SceneJS._webgl.Sampler(gl, this.handle, u_name, u.type, u.size, location);
                 } else {
                     this._uniforms[u_name] = new SceneJS._webgl.Uniform(gl, this.handle, u_name, u.type, u.size, location, valueIndex);
-                    this.uniformValues[valueIndex] = null;
                     ++valueIndex;
                 }
             }
@@ -105,7 +102,6 @@ SceneJS._webgl.Program.prototype.bind = function () {
         return;
     }
     this.gl.useProgram(this.handle);
-    this.uniformValues.length = 0;
 };
 
 SceneJS._webgl.Program.prototype.getUniformLocation = function (name) {
@@ -182,9 +178,6 @@ SceneJS._webgl.Program.prototype.setUniform = function (name, value) {
     }
     var u = this._uniforms[name];
     if (u) {
-        if (this.uniformValues[u.index] !== value || !u.numberValue) {
-            u.setValue(value);
-            this.uniformValues[u.index] = value;
-        }
+        u.setValue(value);
     }
 };

--- a/src/core/webgl/renderBuffer.js
+++ b/src/core/webgl/renderBuffer.js
@@ -77,14 +77,7 @@ SceneJS._webgl.RenderBuffer.prototype._touch = function () {
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_S, this.gl.CLAMP_TO_EDGE);
     this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
 
-    try {
-        // Do it the way the spec requires
-        this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, width, height, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, null);
-    } catch (exception) {
-        // Workaround for what appears to be a Minefield bug.
-        var textureStorage = new WebGLUnsignedByteArray(width * height * 3);
-        this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, width, height, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, textureStorage);
-    }
+    this._setTexture(width, height);
 
     this.gl.bindRenderbuffer(this.gl.RENDERBUFFER, this.buf.renderbuf);
     this.gl.renderbufferStorage(this.gl.RENDERBUFFER, this.gl.DEPTH_COMPONENT16, width, height);
@@ -125,6 +118,17 @@ SceneJS._webgl.RenderBuffer.prototype._touch = function () {
     }
 
     this.bound = false;
+};
+
+SceneJS._webgl.RenderBuffer.prototype._setTexture = function (width, height) {
+    try {
+        // Do it the way the spec requires
+        this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, width, height, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, null);
+    } catch (exception) {
+        // Workaround for what appears to be a Minefield bug.
+        var textureStorage = new WebGLUnsignedByteArray(width * height * 3);
+        this.gl.texImage2D(this.gl.TEXTURE_2D, 0, this.gl.RGBA, width, height, 0, this.gl.RGBA, this.gl.UNSIGNED_BYTE, textureStorage);
+    }
 };
 
 /**

--- a/src/core/webgl/texture2d.js
+++ b/src/core/webgl/texture2d.js
@@ -1,5 +1,15 @@
 
 SceneJS._webgl.Texture2D = function (gl, cfg) {
+
+    try {
+        this._init(gl, cfg);
+    } catch (e) {
+        throw SceneJS_error.fatalError(SceneJS.errors.OUT_OF_VRAM, "Failed to create texture: " + e.message || e);
+    }
+
+};
+
+SceneJS._webgl.Texture2D.prototype._init = function (gl, cfg) {
     /**
      * True as soon as this texture is allocated and ready to go
      * @type {boolean}
@@ -19,39 +29,34 @@ SceneJS._webgl.Texture2D = function (gl, cfg) {
     this.depthCompareMode = 0;
     this.depthCompareFunc = 0;
 
-    try {
-        gl.bindTexture(this.target, this.texture);
+    gl.bindTexture(this.target, this.texture);
 
-        if (cfg.minFilter) {
-            gl.texParameteri(this.target, gl.TEXTURE_MIN_FILTER, cfg.minFilter);
-        }
-
-        if (cfg.magFilter) {
-            gl.texParameteri(this.target, gl.TEXTURE_MAG_FILTER, cfg.magFilter);
-        }
-
-        if (cfg.wrapS) {
-            gl.texParameteri(this.target, gl.TEXTURE_WRAP_S, cfg.wrapS);
-        }
-
-        if (cfg.wrapT) {
-            gl.texParameteri(this.target, gl.TEXTURE_WRAP_T, cfg.wrapT);
-        }
-
-        if (cfg.minFilter == gl.NEAREST_MIPMAP_NEAREST ||
-            cfg.minFilter == gl.LINEAR_MIPMAP_NEAREST ||
-            cfg.minFilter == gl.NEAREST_MIPMAP_LINEAR ||
-            cfg.minFilter == gl.LINEAR_MIPMAP_LINEAR) {
-            gl.generateMipmap(this.target);
-        }
-
-        gl.bindTexture(this.target, null);
-
-        this.allocated = true;
-
-    } catch (e) {
-        throw SceneJS_error.fatalError(SceneJS.errors.OUT_OF_VRAM, "Failed to create texture: " + e.message || e);
+    if (cfg.minFilter) {
+        gl.texParameteri(this.target, gl.TEXTURE_MIN_FILTER, cfg.minFilter);
     }
+
+    if (cfg.magFilter) {
+        gl.texParameteri(this.target, gl.TEXTURE_MAG_FILTER, cfg.magFilter);
+    }
+
+    if (cfg.wrapS) {
+        gl.texParameteri(this.target, gl.TEXTURE_WRAP_S, cfg.wrapS);
+    }
+
+    if (cfg.wrapT) {
+        gl.texParameteri(this.target, gl.TEXTURE_WRAP_T, cfg.wrapT);
+    }
+
+    if (cfg.minFilter == gl.NEAREST_MIPMAP_NEAREST ||
+        cfg.minFilter == gl.LINEAR_MIPMAP_NEAREST ||
+        cfg.minFilter == gl.NEAREST_MIPMAP_LINEAR ||
+        cfg.minFilter == gl.LINEAR_MIPMAP_LINEAR) {
+        gl.generateMipmap(this.target);
+    }
+
+    gl.bindTexture(this.target, null);
+
+    this.allocated = true;
 
     this.bind = function (unit) {
         if (!this.allocated) {
@@ -87,7 +92,7 @@ SceneJS._webgl.Texture2D = function (gl, cfg) {
             this.texture = null;
         }
     };
-};
+}
 
 SceneJS._webgl.clampImageSize = function (image, numPixels) {
     var n = image.width * image.height;
@@ -136,4 +141,3 @@ SceneJS._webgl.nextHighestPowerOfTwo = function (x) {
     }
     return x + 1;
 };
-


### PR DESCRIPTION
Two optimizations implemented here. 

The bigger one is moving all try-catch blocks into their own functions, separate from any significant processing. This allows the browser to optimize the critical code more effectively. The key test I did with this was measuring Geometry._buildNodeCore in the Human. Its execution time went down by ~70%.

A smaller change was to remove uniform value caching from the Program objects, since the uniform objects now cache their values themselves.