### PR TITLE
Xform cores properly updated

### DIFF
--- a/examples/transforms_modelling_hierarchy.html
+++ b/examples/transforms_modelling_hierarchy.html
@@ -12,7 +12,7 @@
             -webkit-user-select: none;
         }
     </style>
-    <script src="../api/latest/scenejs.min.js"></script>
+    <script src="../api/latest/scenejs.js"></script>
     <link href="css/styles.css" rel="stylesheet"/>
 
 </head>
@@ -59,18 +59,19 @@ var scene = SceneJS.createScene({
                     nodes: [
                         // Table leg #1
                         {
-                            type: "translate",
-                            x: -2.0, y: 0.0, z: -2.0,
+                            // Materials can appear anywhere in the hierarchy
+                            type: "material",
+                            color: { r: 1.0, g: 0.4, b: 0.4 },
+
                             nodes: [
                                 {
                                     type: "scale",
                                     x: 0.2, y: 1.0, z: 0.2,
                                     nodes: [
-                                        // Materials can appear anywhere in the hierarchy
-                                        {
-                                            type: "material",
-                                            color: { r: 1.0, g: 0.4, b: 0.4 },
 
+                                        {
+                                            type: "translate",
+                                            x: -2.0, y: 0.0, z: -2.0,
                                             nodes: [
 
                                                 // Box primitive, implemented by plugin at http://scenejs.org/api/latest/plugins/node/geometry/box.js

--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -302,10 +302,6 @@ SceneJS_Engine.prototype.branchDirty = function (node) {
     node.branchDirty = true;
     node.dirty = true;
 
-    if (node._branchDirty) {
-        node._branchDirty();
-    }
-
     for (var n = node.parent; n && !(n.dirty || n.branchDirty); n = n.parent) { // Flag path down to this node
         n.dirty = true;
     }

--- a/src/core/scene/modelXFormStack.js
+++ b/src/core/scene/modelXFormStack.js
@@ -29,8 +29,7 @@ var SceneJS_modelXFormStack = new (function () {
         cores:[], // Child transform cores
         numCores:0, // Number of child transform cores
         dirty:false, // Does this subtree need matrices rebuilt
-        matrixDirty:false,
-        compiling: false // Does this core belong to a node that's compiling?
+        matrixDirty:false
     };
 
     var transformStack = [];
@@ -193,13 +192,10 @@ var SceneJS_modelXFormStack = new (function () {
 
         core.parent = this.top;
         core.dirty = true;
-        core.compiling = false;
 
         if (this.top) {
             this.top.cores[this.top.numCores++] = core;
         }
-
-        core.numCores = filterCores(core.cores, core.numCores);
 
         this.top = core;
 
@@ -213,32 +209,5 @@ var SceneJS_modelXFormStack = new (function () {
 
         dirty = true;
     };
-
-    // Mark core as needing to be pushed back on the stack.
-    // Occurs when the core belongs to a node that's compiling.
-    this.compileCore = function (core) {
-        core.compiling = true;
-    };
-
-    function filterCores(cores, numCores) {
-        var skip = 0;
-        var i;
-
-        for (i = 0; i < numCores; i++) {
-            if (cores[i].compiling) {
-                skip++;
-                continue;
-            }
-            cores[i - skip] = cores[i];
-        }
-
-        var newNumCores = numCores - skip;
-
-        for (i = newNumCores; i < numCores; i++) {
-            cores[i] = null;  // Free memory
-        }
-
-        return newNumCores;
-    }
 
 })();

--- a/src/core/scene/rotate.js
+++ b/src/core/scene/rotate.js
@@ -25,6 +25,9 @@ SceneJS.Rotate.prototype._init = function(params) {
         this._core.buildMatrix = function() {
             core.matrix = SceneJS_math_rotationMat4v(core.angle * Math.PI / 180.0, [core.x, core.y, core.z]);
         };
+
+        this.xformParent = null;
+        this.xformChildren = [];
     }
 };
 
@@ -141,12 +144,60 @@ SceneJS.Rotate.prototype.incAngle = function(angle) {
     this._engine.display.imageDirty = true;
 };
 
-SceneJS.Rotate.prototype._branchDirty = function() {
-    SceneJS_modelXFormStack.compileCore(this._core);
-};
+SceneJS.Rotate.prototype._compile = function (ctx) {
+    var core = this._core;
+    core.numCores = 0;
+    for (var i = 0, len = this.xformChildren.length; i < len; i++) {
+        var child = this.xformChildren[i];
+        if (!this.branchDirty && !child.dirty) {
+            core.cores[core.numCores++] = child._core;
+        }
+    }
 
-SceneJS.Rotate.prototype._compile = function(ctx) {
-    SceneJS_modelXFormStack.push(this._core);
+    for (i = core.numCores, len = core.cores.length; i < len; i++) {
+        core.cores[i] = null;
+    }
+
+    SceneJS_modelXFormStack.push(core);
     this._compileNodes(ctx);
     SceneJS_modelXFormStack.pop();
+};
+
+SceneJS.Rotate.prototype._connect = function () {
+    if (this.xformParent) {
+        return;
+    }
+
+    var n = this;
+
+    while (n.parent) {
+        n = n.parent;
+
+        if (n.xformChildren && this.xformParent !== n) {
+            this.xformParent = n;
+            n.xformChildren.push(this);
+            break;
+        }
+    }
+};
+
+SceneJS.Rotate.prototype._disconnect = function () {
+    if (!this.xformParent) {
+        return;
+    }
+
+    var n = this;
+
+    while (n.parent) {
+        n = n.parent;
+
+        // Still connected to xformParent
+        if (this.xformParent === n) {
+            return;
+        }
+    }
+
+    var siblings = this.xformParent.xformChildren;
+    siblings.splice(siblings.indexOf(this), 1);
+    this.xformParent = null;
 };

--- a/src/core/scene/translate.js
+++ b/src/core/scene/translate.js
@@ -23,6 +23,9 @@ SceneJS.Translate.prototype._init = function(params) {
         this._core.buildMatrix = function() {
             core.matrix = SceneJS_math_translationMat4v([core.x, core.y, core.z], core.matrix);
         };
+
+        this.xformParent = null;
+        this.xformChildren = [];
     }
 };
 
@@ -151,12 +154,60 @@ SceneJS.Translate.prototype.getZ = function() {
     return this._core.z;
 };
 
-SceneJS.Translate.prototype._branchDirty = function() {
-    SceneJS_modelXFormStack.compileCore(this._core);
-};
+SceneJS.Translate.prototype._compile = function (ctx) {
+    var core = this._core;
+    core.numCores = 0;
+    for (var i = 0, len = this.xformChildren.length; i < len; i++) {
+        var child = this.xformChildren[i];
+        if (!this.branchDirty && !child.dirty) {
+            core.cores[core.numCores++] = child._core;
+        }
+    }
 
-SceneJS.Translate.prototype._compile = function(ctx) {
-    SceneJS_modelXFormStack.push(this._core);
+    for (i = core.numCores, len = core.cores.length; i < len; i++) {
+        core.cores[i] = null;
+    }
+
+    SceneJS_modelXFormStack.push(core);
     this._compileNodes(ctx);
     SceneJS_modelXFormStack.pop();
+};
+
+SceneJS.Translate.prototype._connect = function () {
+    if (this.xformParent) {
+        return;
+    }
+
+    var n = this;
+
+    while (n.parent) {
+        n = n.parent;
+
+        if (n.xformChildren && this.xformParent !== n) {
+            this.xformParent = n;
+            n.xformChildren.push(this);
+            break;
+        }
+    }
+};
+
+SceneJS.Translate.prototype._disconnect = function () {
+    if (!this.xformParent) {
+        return;
+    }
+
+    var n = this;
+
+    while (n.parent) {
+        n = n.parent;
+
+        // Still connected to xformParent
+        if (this.xformParent === n) {
+            return;
+        }
+    }
+
+    var siblings = this.xformParent.xformChildren;
+    siblings.splice(siblings.indexOf(this), 1);
+    this.xformParent = null;
 };

--- a/src/core/scene/xform.js
+++ b/src/core/scene/xform.js
@@ -11,6 +11,9 @@ SceneJS.XForm.prototype._init = function (params) {
         SceneJS_modelXFormStack.buildCore(this._core);
 
         this.setElements(params.elements);
+
+        this.xformParent = null;
+        this.xformChildren = [];
     }
 };
 
@@ -73,12 +76,62 @@ SceneJS.XForm.prototype.setElements = function (elements) {
     return this;
 };
 
-SceneJS.XForm.prototype._branchDirty = function() {
-    SceneJS_modelXFormStack.compileCore(this._core);
-};
-
 SceneJS.XForm.prototype._compile = function (ctx) {
-    SceneJS_modelXFormStack.push(this._core);
+    var core = this._core;
+    var i, len;
+
+    core.numCores = 0;
+    for (i = 0, len = this.xformChildren.length; i < len; i++) {
+        var child = this.xformChildren[i];
+        if (!this.branchDirty && !child.dirty) {
+            core.cores[core.numCores++] = child._core;
+        }
+    }
+
+    for (i = core.numCores, len = core.cores.length; i < len; i++) {
+        core.cores[i] = null;
+    }
+
+    SceneJS_modelXFormStack.push(core);
     this._compileNodes(ctx);
     SceneJS_modelXFormStack.pop();
+};
+
+SceneJS.XForm.prototype._connect = function () {
+    if (this.xformParent) {
+        return;
+    }
+
+    var n = this;
+
+    while (n.parent) {
+        n = n.parent;
+
+        if (n.xformChildren && this.xformParent !== n) {
+            this.xformParent = n;
+            n.xformChildren.push(this);
+            break;
+        }
+    }
+};
+
+SceneJS.XForm.prototype._disconnect = function () {
+    if (!this.xformParent) {
+        return;
+    }
+
+    var n = this;
+
+    while (n.parent) {
+        n = n.parent;
+
+        // Still connected to xformParent
+        if (this.xformParent === n) {
+            return;
+        }
+    }
+
+    var siblings = this.xformParent.xformChildren;
+    siblings.splice(siblings.indexOf(this), 1);
+    this.xformParent = null;
 };


### PR DESCRIPTION
Fixes the fact that transform nodes would not properly update nodes in the Xformstack. The key problem is that knowing which cores need to be pushed on the stack requires knowledge of which nodes are going to be compiled and knowledge of the transform hierarchy, and no part of the system had knowledge of both. 

My solution was to consolidate this knowledge in the transform nodes themselves. They now have `xformParent` and `xformChildren` properties to track parent and child transform nodes. Setting these properties currently requires traversals whenever nodes are connected or disconnected from the scene. These traversals take place in new `_connect` and `_disconnect` callback methods that any node can implement (similar to `_init` or `_compile`). 

I dislike having to traverse the scene on [connections and disconnections](https://github.com/xeolabs/scenejs/compare/master...tsherif:fix-xforms?expand=1#diff-52ca96f440d36477bdee14b81ae39a81R445), but I can't think of any other way to properly relay the necessary information for maintaining the xform hierarchy.

I'm not seeing any noticeable performance degradation in my tests, but let me know if you can think of a more efficient way to do this.