### PR TITLE
Allow compilation to be paused

### DIFF
--- a/src/core/engine.js
+++ b/src/core/engine.js
@@ -65,6 +65,11 @@ var SceneJS_Engine = function (json, options) {
     this._sceneBranchesDirty = false;
 
     /**
+     * Flag to prevent engine from re-compiling the scene graph
+     */
+    this._compilationPaused = false;
+
+    /**
      * List of nodes scheduled for destruction by #destroyNode
      * Destructions are done in a batch at the end of each render so as not to disrupt the render.
      */
@@ -583,9 +588,27 @@ SceneJS_Engine.prototype._needCompile = function () {
 };
 
 /**
+ * Prevent engine from compiling the scene graph
+ */
+SceneJS_Engine.prototype.pauseCompilation = function () {
+    this._compilationPaused = true;
+};
+
+/**
+ * Resume compilation of scene graph
+ */
+SceneJS_Engine.prototype.resumeCompilation = function () {
+    this._compilationPaused = false;
+};
+
+/**
  * Performs any pending scene compilations or display rebuilds
  */
 SceneJS_Engine.prototype.compile = function () {
+    if (this._compilationPaused) {
+        return;
+    }
+
     if (this._sceneBranchesDirty || this.sceneDirty) { // Need scene graph compilation
         this._sceneBranchesDirty = false;
         SceneJS_events.fireEvent(SceneJS_events.SCENE_COMPILING, {  // Notify compilation support start

--- a/src/core/scene/scene.js
+++ b/src/core/scene/scene.js
@@ -106,9 +106,23 @@ SceneJS.Scene.prototype.renderFrame = function (params) {
 };
 
 /**
+ * Prevent re-compilation of scene graph.
+ */
+SceneJS.Scene.prototype.pauseCompilation = function () {
+    return this._engine.pauseCompilation();
+};
+
+/**
+ * Resume re-compilation of scene graph.
+ */
+SceneJS.Scene.prototype.resumeCompilation = function () {
+    return this._engine.resumeCompilation();
+};
+
+/**
  * Force compilation of the scene graph.
  */
-SceneJS.Scene.prototype.compile = function (params) {
+SceneJS.Scene.prototype.compile = function () {
     return this._engine.compile();
 };
 


### PR DESCRIPTION
The use case for this is when you're making significant updates to the scene graph, you can get significant improvements in performance if compilation isn't occurring on each frame. This can currently only be done by pausing the rendering, but that means interactivity gets interrupted, which isn't the case if compilation is paused directly. 