### PR TITLE
Respect size of valid input geometry indices

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -625,6 +625,7 @@
             "optimization_instancing",
             "optimization_textureAtlas",
             "optimization_vertexSharing",
+            "optimization_indexSize",
             "optimization_uintIndex"
         ],
 

--- a/examples/optimization_indexSize.html
+++ b/examples/optimization_indexSize.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>SceneJS Example</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+
+    <script src="../api/latest/scenejs.js"></script>
+    <link href="css/styles.css" rel="stylesheet"/>
+
+    <style>
+        body {
+            margin: 0;
+            -moz-user-select: -moz-none;
+            -khtml-user-select: none;
+            -webkit-user-select: none;
+        }
+
+        #info {
+            position: absolute;
+            top: 200px;
+            width: 100%;
+            color: #ffffff;
+            padding: 5px;
+            font-family: Monospace;
+            font-size: 18px;
+            text-align: center;
+            background: black;
+            opacity: 0.6;
+            z-index: 100000;
+        }
+
+        #infoTxt {
+            font-weight: bold;
+        }
+
+        #map {
+            position: absolute;
+            top: 200px;
+            left: 40px;
+            height: 256px;
+            width: 256px;
+        }
+
+        #map img {
+            width: 100%;
+        }
+
+        #map canvas {
+            position: absolute;
+            top: 0;
+            left: 0;
+        }
+    </style>
+</head>
+
+<body>
+
+<div id="infoDark">
+    <a href="http://scenejs.org" target="_other">SceneJS</a> - optimization - Index size
+    <br>
+    SceneJS geometry nodes allow control over index size. If a valid typed array is provided (Uint8Array, Uint16Array, <BR>
+    Uint32Array), it will be used to create the index buffer. Otherwise, it will default to the largest available index size.<BR>
+    <div id="geo-info"></div>
+</div>
+
+<script>
+
+
+    // Point SceneJS to the bundled plugins
+    SceneJS.setConfigs({
+        pluginPath: "../api/latest/plugins"
+    });
+
+    // Create geometry description
+    // If IndexArrayConstructor is provided (Uint8Array, Uint16Array,
+    // Uint32Array), it will be sued to create the index array.
+    function createGeometry(id, IndexArrayConstructor) {
+        var geo = {
+            type: "geometry",
+            id: id,
+            primitive: "triangles",
+            positions: [
+                /* v0-v1-v2-v3 front
+                 */
+                1, 1, 1,
+                -1, 1, 1
+                ,
+                -1, -1, 1,
+                1, -1, 1,
+                /* v0-v3-v4-v1 right
+                 */
+                1, 1, 1,
+                1, -1, 1,
+                1, -1, -1,
+                1, 1, -1,
+                /* v0-v1-v6-v1 top
+                 */
+                1, 1, 1,
+                1, 1, -1,
+                -1, 1, -1,
+                -1, 1, 1,
+                /* v1-v6-v7-v2 left
+                 */
+                -1, 1, 1,
+                -1, 1, -1,
+                -1, -1, -1,
+                -1, -1, 1,
+                /* v7-v4-v3-v2 bottom
+                 */
+                -1, -1, -1,
+                1, -1, -1,
+                1, -1, 1,
+                -1, -1, 1,
+                /* v4-v7-v6-v1 back
+                 */
+                1, -1, -1,
+                -1, -1, -1,
+                -1, 1, -1,
+                1, 1, -1
+            ],
+
+            normals: [
+                /* v0-v1-v2-v3 front
+                 */
+                0, 0, 1,
+                0, 0, 1,
+                0, 0, 1,
+                0, 0, 1,
+                /* v0-v3-v4-v5 right
+                 */
+                1, 0, 0,
+                1, 0, 0,
+                1, 0, 0,
+                1, 0, 0,
+                /* v0-v5-v6-v1 top
+                 */
+                0, 1, 0,
+                0, 1, 0,
+                0, 1, 0,
+                0, 1, 0,
+                /* v1-v6-v7-v2 left
+                 */
+                -1, 0, 0,
+                -1, 0, 0,
+                -1, 0, 0,
+                -1, 0, 0,
+                /* v7-v4-v3-v2 bottom
+                 */
+                0, -1, 0,
+                0, -1, 0,
+                0, -1, 0,
+                0, -1, 0,
+                /* v4-v7-v6-v5 back
+                 */
+                0, 0, -1,
+                0, 0, -1,
+                0, 0, -1,
+                0, 0, -1
+            ],
+
+            uv: [
+                /* v0-v1-v2-v3 front
+                 */
+                5, 5,
+                0, 5,
+                0, 0,
+                5, 0,
+                /* v0-v3-v4-v5 right
+                 */
+                0, 5,
+                0, 0,
+                5, 0,
+                5, 5,
+                /* v0-v5-v6-v1 top
+                 */
+                5, 0,
+                5, 5,
+                0, 5,
+                0, 0,
+                /* v1-v6-v7-v2 left
+                 */
+                5, 5,
+                0, 5,
+                0, 0,
+                5, 0,
+                /* v7-v4-v3-v2 bottom
+                 */
+                0, 0,
+                5, 0,
+                5, 5,
+                0, 5,
+                /* v4-v7-v6-v5 back
+                 */
+                0, 0,
+                5, 0,
+                5, 5,
+                0, 5
+            ]
+        };
+
+        var indices = [
+            0, 1, 2,
+            0, 2, 3,
+            // front
+            4, 5, 6,
+            4, 6, 7,
+            // right
+            8, 9, 10,
+            8, 10, 11,
+            // top
+            12, 13, 14,
+            12, 14, 15,
+            // left
+            16, 17, 18,
+            16, 18, 19,
+            // bottom
+            20, 21, 22,
+            20, 22, 23
+
+        ];
+
+        if (IndexArrayConstructor) {
+            indices = new IndexArrayConstructor(indices);
+        }
+
+        geo.indices = indices;
+
+        return geo;
+    }
+
+    // Define scene
+    var scene = SceneJS.createScene({
+        nodes: [
+            // Mouse-orbited camera, implemented by plugin at
+            // http://scenejs.org/api/latest/plugins/node/cameras/orbit.js
+            {
+                type: "cameras/orbit",
+                zoom: 10,
+                zoomSensitivity: 0.1,
+
+                nodes: [
+                    {
+                        type: "translate",
+                        x: -2,
+                        y: 2,
+                        nodes: [
+                            {
+                                type: "material",
+                                color: { r: 1 , g: 0, b: 0},
+                                nodes: [
+                                    createGeometry("red") // Default to largest possible (Uint16Array or Uint32Array)
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        type: "translate",
+                        x: 2,
+                        y: 2,
+                        nodes: [
+                            {
+                                type: "material",
+                                color: { r: 0 , g: 1, b: 0},
+                                nodes: [
+                                    createGeometry("green", Uint8Array)
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        type: "translate",
+                        x: -2,
+                        y: -2,
+                        nodes: [
+                            {
+                                type: "material",
+                                color: { r: 0 , g: 0, b: 1},
+                                nodes: [
+                                    createGeometry("blue", Uint16Array)
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        type: "translate",
+                        x: 2,
+                        y: -2,
+                        nodes: [
+                            {
+                                type: "material",
+                                color: { r: 1 , g: 1, b: 0},
+                                nodes: [
+                                    createGeometry("yellow", Uint32Array)
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    });
+
+    function arrayTypeString(type) {
+        switch(type) {
+            case Uint8Array : return "8-bit";
+            case Uint16Array : return "16-bit";
+            case Uint32Array : return "32-bit";
+        }
+    }
+
+    var geoInfo = document.getElementById("geo-info");
+
+    ["Red", "green", "blue", "yellow"].forEach(function(color) {
+        scene.getNode(color.toLowerCase(), function(node) {
+            geoInfo.innerHTML += [
+                color,
+                "cube is using",
+                arrayTypeString(node._core.arrays.indices.constructor),
+                "indices, "
+            ].join(" ");
+        });
+    });
+
+</script>
+</body>
+</html>

--- a/src/core/scene/geometry.js
+++ b/src/core/scene/geometry.js
@@ -175,7 +175,10 @@ new (function () {
         }
 
         if (data.indices) {
-            if (data.indices.constructor != Uint16Array && data.indices.constructor != Uint32Array) {
+            if (data.indices.constructor != Uint8Array &&
+                data.indices.constructor != Uint16Array &&
+                data.indices.constructor != Uint32Array)
+            {
                 data.indices = new IndexArrayType(data.indices);
             }
 
@@ -549,8 +552,13 @@ new (function () {
             this._boundary = null;
             var core = this._core;
             core.indexBuf.bind();
-            var IndexArrayType = this._engine.canvas.UINT_INDEX_ENABLED ? Uint32Array : Uint16Array;
-            core.indexBuf.setData(new IndexArrayType(data.indices), data.indicesOffset || 0);
+
+            // Make sure indices remain of the same type.
+            if (data.indices.constructor != core.arrays.indices.constructor) {
+                data.indices = new core.arrays.indices.constructor(data.indices);
+            }
+
+            core.indexBuf.setData(data.indices, data.indicesOffset || 0);
             core.arrays.indices.set(data.indices, data.indicesOffset || 0);
             this._engine.display.imageDirty = true;
         }


### PR DESCRIPTION
Small update to allow for optimizing geometry indices. The geometry node will now use any valid index Array type (Uint8Array, Uint16Array, Uint32Array). This allows users to choose smaller indices when they know they're dealing with smaller meshes.

Also created an example.